### PR TITLE
Update: Cilium to 1.18.3 and Gateway API CRD references to v1.3.0

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -154,12 +154,6 @@ tasks:
       - cilium connectivity test
 
   ####################
-  # Packer Templates
-  ####################
-  # Packer tasks are defined in packer/windows_server_2025/Taskfile.yml
-  # Use them with: task packer:TASK_NAME
-
-  ####################
   # Code Quality
   ####################
 

--- a/cspell.json
+++ b/cspell.json
@@ -35,7 +35,8 @@
     "*.vhdx",
     "packer/windows_server_2025/.env",
     "**/*.secrets.*",
-    "sensitive/**"
+    "sensitive/**",
+    "backend.config"
   ],
   "language": "en",
   "maxDuplicateProblems": 3,

--- a/k8s/infra/crds/kustomization.yaml
+++ b/k8s/infra/crds/kustomization.yaml
@@ -3,9 +3,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.1.0/config/crd/standard/gateway.networking.k8s.io_gatewayclasses.yaml
-  - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.1.0/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml # Experimental required to use "io.cilium/lb-ipam-ips" in the gateway
-  - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.1.0/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
-  - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.1.0/config/crd/standard/gateway.networking.k8s.io_referencegrants.yaml
-  - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.1.0/config/crd/standard/gateway.networking.k8s.io_grpcroutes.yaml
-  - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.1.0/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
+  - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.3.0/config/crd/standard/gateway.networking.k8s.io_gatewayclasses.yaml
+  - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.3.0/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
+  - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.3.0/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+  - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.3.0/config/crd/standard/gateway.networking.k8s.io_referencegrants.yaml
+  - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.3.0/config/crd/standard/gateway.networking.k8s.io_grpcroutes.yaml
+  - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.3.0/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml

--- a/k8s/infra/network/cilium/kustomization.yaml
+++ b/k8s/infra/network/cilium/kustomization.yaml
@@ -8,7 +8,7 @@ resources:
 helmCharts:
   - name: cilium
     repo: https://helm.cilium.io
-    version: 1.17.4
+    version: 1.18.3
     releaseName: "cilium"
     includeCRDs: true
     namespace: kube-system

--- a/terraform/kubernetes/modules/talos/talos_machine_config/control-plane.yaml.tftpl
+++ b/terraform/kubernetes/modules/talos/talos_machine_config/control-plane.yaml.tftpl
@@ -23,12 +23,12 @@ cluster:
     disabled: true
   #need to install gateway api manifests before cilium deployment. GatewayClass acceptance
   extraManifests:
-    - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.1.0/config/crd/standard/gateway.networking.k8s.io_gatewayclasses.yaml
-    - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.1.0/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
-    - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.1.0/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
-    - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.1.0/config/crd/standard/gateway.networking.k8s.io_referencegrants.yaml
-    - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.1.0/config/crd/standard/gateway.networking.k8s.io_grpcroutes.yaml
-    - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.1.0/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
+    - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.3.0/config/crd/standard/gateway.networking.k8s.io_gatewayclasses.yaml
+    - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.3.0/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
+    - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.3.0/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+    - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.3.0/config/crd/standard/gateway.networking.k8s.io_referencegrants.yaml
+    - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.3.0/config/crd/standard/gateway.networking.k8s.io_grpcroutes.yaml
+    - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.3.0/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
     - https://raw.githubusercontent.com/alex1989hu/kubelet-serving-cert-approver/main/deploy/standalone-install.yaml
     - https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml
 


### PR DESCRIPTION
This pull request primarily updates the Kubernetes Gateway API CRDs and the Cilium Helm chart version across the codebase to ensure compatibility and access to the latest features and fixes. It also includes minor improvements to code quality and security configuration files.

**Kubernetes Gateway API & Cilium Upgrades:**

* Updated all references to Gateway API CRDs from version `v1.1.0` to `v1.3.0` in `k8s/infra/crds/kustomization.yaml` and `terraform/kubernetes/modules/talos/talos_machine_config/control-plane.yaml.tftpl` for improved feature support and compatibility. [[1]](diffhunk://#diff-dc2d907083fac32fa9886b478d6317b05da400d622510973d5018eacab98da74L6-R11) [[2]](diffhunk://#diff-c6fa5f58f926568a55e028685aabaaf89ee1220fe7d1f2c00f7e0f892a59516dL26-R31)
* Upgraded the Cilium Helm chart version from `1.17.4` to `1.18.3` in `k8s/infra/network/cilium/kustomization.yaml` to use the latest Cilium networking features and bug fixes.

**Security & Code Quality:**

* Added `backend.config` to the list of files ignored by the spell checker in `cspell.json`, likely to avoid false positives on configuration files.
* Removed the commented-out Packer template section from `Taskfile.yml` for cleaner task definitions.