### PR TITLE
Update argo-cd helm chart version to 9.0.5

### DIFF
--- a/k8s/infra/controllers/argocd/kustomization.yaml
+++ b/k8s/infra/controllers/argocd/kustomization.yaml
@@ -10,7 +10,7 @@ resources:
 helmCharts:
   - name: argo-cd
     repo: https://argoproj.github.io/argo-helm
-    version: 8.2.2
+    version: 9.0.5
     releaseName: "argocd"
     namespace: argocd
     valuesFile: values.yaml


### PR DESCRIPTION
This pull request updates the Argo CD Helm chart version in the Kubernetes controller configuration. The main change is a version bump to ensure the deployment uses the latest features and fixes.

Helm chart version update:

* Upgraded the `argo-cd` Helm chart from version `8.2.2` to `9.0.5` in `k8s/infra/controllers/argocd/kustomization.yaml` for improved stability and features.