### PR TITLE
Update helm chart versions for cert-manager, sealed-secrets, kube-pro…

### DIFF
--- a/k8s/infra/controllers/cert-manager/kustomization.yaml
+++ b/k8s/infra/controllers/cert-manager/kustomization.yaml
@@ -9,7 +9,7 @@ resources:
 helmCharts:
   - name: cert-manager
     repo: https://charts.jetstack.io
-    version: v1.18.2
+    version: v1.19.1
     releaseName: cert-manager
     namespace: cert-manager
     valuesFile: values.yaml

--- a/k8s/infra/controllers/sealed-secrets/kustomization.yaml
+++ b/k8s/infra/controllers/sealed-secrets/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Kustomization
 helmCharts:
   - name: sealed-secrets
     repo: https://bitnami-labs.github.io/sealed-secrets
-    version: 2.17.3
+    version: 2.17.7
     releaseName: "sealed-secrets-controller"
     includeCRDs: true
     namespace: kube-system

--- a/k8s/infra/monitoring/prometheus-stack/kube-prometheus-stack.yaml
+++ b/k8s/infra/monitoring/prometheus-stack/kube-prometheus-stack.yaml
@@ -10,7 +10,7 @@ spec:
   sources:
     - repoURL: https://prometheus-community.github.io/helm-charts
       chart: kube-prometheus-stack
-      targetRevision: 75.15.0
+      targetRevision: 78.5.0
       helm:
         valueFiles:
           - $values/k8s/infra/monitoring/prometheus-stack/values.yaml

--- a/k8s/infra/network/dns/adguard/deployment.yaml
+++ b/k8s/infra/network/dns/adguard/deployment.yaml
@@ -18,12 +18,17 @@ spec:
       initContainers:
         - name: copy-base-config
           image: busybox
-          command: [ "cp", "/tmp/AdGuardHome.yaml", "/opt/adguardhome/conf/AdGuardHome.yaml" ]
+          command:
+            [
+              "cp",
+              "/tmp/AdGuardHome.yaml",
+              "/opt/adguardhome/conf/AdGuardHome.yaml",
+            ]
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
             capabilities:
-              drop: [ "ALL" ]
+              drop: ["ALL"]
           volumeMounts:
             - name: config
               mountPath: /tmp/AdGuardHome.yaml
@@ -32,12 +37,17 @@ spec:
               mountPath: /opt/adguardhome/conf
         - name: append-users
           image: busybox
-          command: [ "sh", "-c", "cat /tmp/users.yaml >> /opt/adguardhome/conf/AdGuardHome.yaml" ]
+          command:
+            [
+              "sh",
+              "-c",
+              "cat /tmp/users.yaml >> /opt/adguardhome/conf/AdGuardHome.yaml",
+            ]
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
             capabilities:
-              drop: [ "ALL" ]
+              drop: ["ALL"]
           volumeMounts:
             - name: users
               mountPath: /tmp/users.yaml
@@ -46,7 +56,7 @@ spec:
               mountPath: /opt/adguardhome/conf
       containers:
         - name: adguard
-          image: docker.io/adguard/adguardhome:v0.107.63 # renovate: docker=docker.io/adguard/adguardhome
+          image: docker.io/adguard/adguardhome:v0.107.68 # renovate: docker=docker.io/adguard/adguardhome
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
@@ -85,6 +95,6 @@ spec:
           secret:
             secretName: adguard-users-secrets
         - name: config-folder
-          emptyDir: { }
+          emptyDir: {}
         - name: work-folder
-          emptyDir: { }
+          emptyDir: {}

--- a/k8s/infra/storage/proxmox-csi/kustomization.yaml
+++ b/k8s/infra/storage/proxmox-csi/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Kustomization
 helmCharts:
   - name: proxmox-csi-plugin
     repo: oci://ghcr.io/sergelogvinov/charts
-    version: 0.3.13
+    version: 0.3.16
     releaseName: proxmox-csi-plugin
     includeCRDs: true
     namespace: csi-proxmox


### PR DESCRIPTION
This pull request updates several Kubernetes infrastructure components by bumping Helm chart and container image versions, improving configuration formatting, and adding session persistence to the AdGuard HTTP route. These changes help keep dependencies up to date, improve maintainability, and enhance service reliability.

**Helm Chart and Image Version Upgrades:**

* Upgraded `cert-manager` Helm chart from `v1.18.2` to `v1.19.1` in `k8s/infra/controllers/cert-manager/kustomization.yaml`.
* Upgraded `sealed-secrets` Helm chart from `2.17.3` to `2.17.7` in `k8s/infra/controllers/sealed-secrets/kustomization.yaml`.
* Upgraded `kube-prometheus-stack` Helm chart from `75.15.0` to `78.5.0` in `k8s/infra/monitoring/prometheus-stack/kube-prometheus-stack.yaml`.
* Upgraded `proxmox-csi-plugin` Helm chart from `0.3.13` to `0.3.16` in `k8s/infra/storage/proxmox-csi/kustomization.yaml`.
* Updated AdGuard container image from `v0.107.63` to `v0.107.68` in `k8s/infra/network/dns/adguard/deployment.yaml`.

**Configuration and Feature Enhancements:**

* Improved formatting of `initContainers` and `command` fields in AdGuard deployment for better readability and maintainability in `k8s/infra/network/dns/adguard/deployment.yaml`. [[1]](diffhunk://#diff-2622babd90a0b3f1b4696ab1fdba52a316da8d1a03855b8608b25faa8533caf4L21-R26) [[2]](diffhunk://#diff-2622babd90a0b3f1b4696ab1fdba52a316da8d1a03855b8608b25faa8533caf4L35-R45)
