### PR TITLE
cert-manager: Set recursive DNS server | Gateway: Update issuer to cluster-issuer

### DIFF
--- a/k8s/infra/controllers/cert-manager/values.yaml
+++ b/k8s/infra/controllers/cert-manager/values.yaml
@@ -4,6 +4,7 @@ crds:
   keep: true
 extraArgs:
   - "--enable-gateway-api"
+  - "--dns01-recursive-nameservers=86.54.11.100:53,9.9.9.9:53" # DNS4EU Unfiltered + Quad9
 
 resources:
   limits:

--- a/k8s/infra/network/gateway/gw-internal.yaml
+++ b/k8s/infra/network/gateway/gw-internal.yaml
@@ -4,7 +4,7 @@ metadata:
   name: internal
   namespace: gateway
   annotations:
-    cert-manager.io/issuer: cloudflare-cluster-issuer
+    cert-manager.io/cluster-issuer: cloudflare-cluster-issuer
 spec:
   gatewayClassName: cilium
   infrastructure:


### PR DESCRIPTION
This pull request includes two updates to the Kubernetes infrastructure for certificate management and networking. The changes improve DNS resolver configuration for cert-manager and fix an annotation for the internal gateway to use the correct cluster issuer.

Certificate management improvements:
* Added custom DNS resolvers (DNS4EU Unfiltered and Quad9) to the cert-manager controller by setting the `--dns01-recursive-nameservers` argument in `values.yaml`. This solves an issue where DNS-01 challenges relying on CoreDNS caching cause long certificate challenges.

Networking configuration fix:
* Corrected the gateway annotation from `cert-manager.io/issuer` to `cert-manager.io/cluster-issuer` for the internal gateway, ensuring it uses the intended cluster-wide issuer for certificate management.