### PR TITLE
Increase memory requests and limits for dex resources in ArgoCD

### DIFF
--- a/k8s/infra/controllers/argocd/values.yaml
+++ b/k8s/infra/controllers/argocd/values.yaml
@@ -4,7 +4,6 @@
 global:
   domain: argocd.k8s.ghiot.be
 
-
 configs:
   cm:
     create: true
@@ -39,9 +38,9 @@ dex:
   resources:
     requests:
       cpu: 10m
-      memory: 32Mi
+      memory: 64Mi
     limits:
-      memory: 128Mi
+      memory: 256Mi
 
 redis:
   resources:


### PR DESCRIPTION
This pull request updates resource allocations for the `dex` component in the ArgoCD deployment and makes a minor formatting adjustment in the `values.yaml` configuration file.

This update is due to a CrashLoopBackOff issue. The container returned an exit code 139.

Resource allocation updates:

* Increased the memory request for the `dex` container from `32Mi` to `64Mi` (`k8s/infra/controllers/argocd/values.yaml`).
* Increased the memory limit for the `dex` container from `128Mi` to `256Mi` (`k8s/infra/controllers/argocd/values.yaml`).

Configuration formatting:

* Removed an unnecessary blank line after the `global.domain` setting to improve YAML formatting (`k8s/infra/controllers/argocd/values.yaml`).…guration