### PR TITLE
Cross namespace issue with Hubbles's HttpRoute

### DIFF
--- a/k8s/infra/monitoring/hubble/http-route.yaml
+++ b/k8s/infra/monitoring/hubble/http-route.yaml
@@ -2,7 +2,7 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: hubble-ui
-  namespace: monitoring
+  namespace: kube-system
 spec:
   parentRefs:
     - name: internal
@@ -17,4 +17,3 @@ spec:
       backendRefs:
         - name: hubble-ui
           port: 80
-          namespace: kube-system

--- a/terraform/azure/global/main.tf
+++ b/terraform/azure/global/main.tf
@@ -101,7 +101,7 @@ resource "azurerm_key_vault" "main" {
 
   sku_name                  = "standard"
   enable_rbac_authorization = true
-  purge_protection_enabled  = false
+  purge_protection_enabled  = true
 
   network_acls {
     default_action = "Deny"


### PR DESCRIPTION
Revert the Hubble's HttpRoute to kube-system namespace