### PR TITLE
Enable hostLegacyRouting in Cilium configuration

### DIFF
--- a/cspell-dict.txt
+++ b/cspell-dict.txt
@@ -16,6 +16,7 @@ aztfmod
 azurecaf
 behaviour
 bitnami
+bpf
 bpg
 bthserv
 buildah

--- a/k8s/infra/network/cilium/values.yaml
+++ b/k8s/infra/network/cilium/values.yaml
@@ -26,6 +26,11 @@ cgroup:
     enabled: false
   hostRoot: /sys/fs/cgroup
 
+# https://www.talos.dev/latest/talos-guides/network/host-dns/#forwarding-kube-dns-to-host-dns
+# https://docs.cilium.io/en/stable/operations/performance/tuning/#ebpf-host-routing
+bpf:
+  hostLegacyRouting: true
+
 # https://docs.cilium.io/en/stable/network/concepts/ipam/
 ipam:
   mode: kubernetes


### PR DESCRIPTION
This pull request introduces a configuration change to enable legacy BPF host routing in the Cilium network stack and adds a new term to the custom spelling dictionary. The most important changes are as follows:

Cilium network configuration:

* Enabled legacy BPF host routing by setting `bpf.hostLegacyRouting` to `true` in the `k8s/infra/network/cilium/values.yaml` file, following best practices for host DNS forwarding and eBPF host routing.

Spelling dictionary update:

* Added the term `bpf` to the `cspell-dict.txt` custom spelling dictionary to prevent it from being flagged as a spelling error.