### PR TITLE
Add dnsConfig with ndots option to deployments Alpine-based containers

### DIFF
--- a/cspell-dict.txt
+++ b/cspell-dict.txt
@@ -115,6 +115,7 @@ MSR
 mtools
 mvance
 Ncb
+ndots
 NDRG
 netkvm
 netops

--- a/k8s/apps/media/arr/lidarr/deployment.yaml
+++ b/k8s/apps/media/arr/lidarr/deployment.yaml
@@ -28,6 +28,13 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
         seccompProfile:
           type: RuntimeDefault
+      dnsConfig:
+        options:
+          # Lower ndots to avoid search-domain expansion issues (musl/glibc resolver short-circuit)
+          # and ensure external and cluster FQDNs resolve correctly.
+          # Use this on other Alpine based containers if I face similar issues.
+          - name: ndots
+            value: "1"
       containers:
         - name: lidarr
           image: ghcr.io/home-operations/lidarr:3.0.1 # renovate: docker=ghcr.io/home-operations/lidarr

--- a/k8s/apps/media/arr/prowlarr/deployment.yaml
+++ b/k8s/apps/media/arr/prowlarr/deployment.yaml
@@ -28,6 +28,13 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
         seccompProfile:
           type: RuntimeDefault
+      dnsConfig:
+        options:
+          # Lower ndots to avoid search-domain expansion issues (musl/glibc resolver short-circuit)
+          # and ensure external and cluster FQDNs resolve correctly.
+          # Use this on other Alpine based containers if I face similar issues.
+          - name: ndots
+            value: "1"
       containers:
         - name: prowlarr
           image: ghcr.io/home-operations/prowlarr:2.1.5 # renovate: docker=ghcr.io/home-operations/prowlarr

--- a/k8s/apps/media/arr/radarr/deployment.yaml
+++ b/k8s/apps/media/arr/radarr/deployment.yaml
@@ -28,6 +28,13 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
         seccompProfile:
           type: RuntimeDefault
+      dnsConfig:
+        options:
+          # Lower ndots to avoid search-domain expansion issues (musl/glibc resolver short-circuit)
+          # and ensure external and cluster FQDNs resolve correctly.
+          # Use this on other Alpine based containers if I face similar issues.
+          - name: ndots
+            value: "1"
       containers:
         - name: radarr
           image: ghcr.io/home-operations/radarr:6.0.3 # renovate: docker=ghcr.io/home-operations/radarr

--- a/k8s/apps/media/arr/sonarr/deployment.yaml
+++ b/k8s/apps/media/arr/sonarr/deployment.yaml
@@ -28,6 +28,13 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
         seccompProfile:
           type: RuntimeDefault
+      dnsConfig:
+        options:
+          # Lower ndots to avoid search-domain expansion issues (musl/glibc resolver short-circuit)
+          # and ensure external and cluster FQDNs resolve correctly.
+          # Use this on other Alpine based containers if I face similar issues.
+          - name: ndots
+            value: "1"
       containers:
         - name: sonarr
           image: ghcr.io/home-operations/sonarr:4.0.16 # renovate: docker=ghcr.io/home-operations/sonarr

--- a/k8s/apps/utils/torrent/deployment.yaml
+++ b/k8s/apps/utils/torrent/deployment.yaml
@@ -27,6 +27,13 @@ spec:
         fsGroupChangePolicy: Always
         seccompProfile:
           type: RuntimeDefault
+      dnsConfig:
+        options:
+          # Lower ndots to avoid search-domain expansion issues (musl/glibc resolver short-circuit)
+          # and ensure external and cluster FQDNs resolve correctly.
+          # Use this on other Alpine based containers if I face similar issues.
+          - name: ndots
+            value: "1"
       containers:
         - name: git-sync-vuetorrent
           image: registry.k8s.io/git-sync/git-sync:v4.5.0 # renovate: docker=registry.k8s.io/git-sync/git-sync


### PR DESCRIPTION
### Detailed Explanation

This change adjusts the Pod's DNS resolver configuration to use `ndots=1` instead of the Kubernetes default `ndots=5`.

#### Problem

With `ndots=5`, any hostname containing fewer than 5 dots (e.g., `radarr.servarr.com` or `torrent.torrent`) is treated as a **relative** domain first.  
The resolver appends each entry from the `search` list before attempting the hostname as an absolute FQDN.  
In our environment, the pod had the following `search` domains:

```
arr.svc.cluster.local
svc.cluster.local
cluster.local
ad.ghiot.be
ghiot.be
```

This caused lookups such as `radarr.servarr.com` to be expanded and queried as:

```
radarr.servarr.com.arr.svc.cluster.local
radarr.servarr.com.svc.cluster.local
radarr.servarr.com.cluster.local
radarr.servarr.com.ad.ghiot.be
radarr.servarr.com.ghiot.be
```

Only after all of these failed would the resolver *eventually* try `radarr.servarr.com` as an absolute FQDN.  
However, some of these intermediate lookups returned authoritative NXDOMAIN or were slow to respond, which caused the resolver to **stop early**, resulting in Radarr logging:

```
Name does not resolve
```

#### Why Alpine/musl Matters

The Radarr container runs on **Alpine Linux**, which uses **musl libc**.  
Musl implements DNS resolution more strictly than glibc and does not always fall back to retrying the absolute hostname after NXDOMAIN during search expansion.

In other words:

- **musl + ndots:5 + multiple search domains** → DNS **fails**
- **glibc + ndots:5** → typically just **slow**, but still resolves eventually

So the same configuration would likely have behaved differently (and more leniently) under glibc-based images (Debian/Ubuntu).

#### Fix

We explicitly set:

```yaml
dnsConfig:
  options:
  - name: ndots
    value: "1"
```

With `ndots=1`, any hostname containing at least one dot is attempted **as an absolute FQDN first**, avoiding unnecessary search suffix expansion and preventing premature NXDOMAIN failures.

#### Result

- External hostnames (e.g., `radarr.servarr.com`) resolve reliably.
- Internal Kubernetes service names containing dots (e.g., `torrent.torrent`) continue to resolve correctly via CoreDNS.
- Radarr no longer fails DNS resolution.
- Name lookups are faster and more deterministic.

No functional behavior is lost, and local single-label service names (e.g., `redis`) still resolve normally using namespace-based search.
