### PR TITLE
Add Bazarr deployment, service, PVC, and HTTP route configurations

### DIFF
--- a/cspell-dict.txt
+++ b/cspell-dict.txt
@@ -14,6 +14,7 @@ autounattend
 avd
 aztfmod
 azurecaf
+bazarr
 behaviour
 bitnami
 bpf

--- a/k8s/apps/media/arr/bazarr/deployment.yaml
+++ b/k8s/apps/media/arr/bazarr/deployment.yaml
@@ -1,0 +1,76 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bazarr
+  namespace: arr
+  labels:
+    app: bazarr
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: bazarr
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      namespace: bazarr
+      labels:
+        app: bazarr
+    spec:
+      nodeSelector:
+        topology.kubernetes.io/zone: hsp-proxmox0
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 2501
+        runAsGroup: 2501
+        fsGroup: 2501
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
+      dnsConfig:
+        options:
+          # Lower ndots to avoid search-domain expansion issues (musl/glibc resolver short-circuit)
+          # and ensure external and cluster FQDNs resolve correctly.
+          # Use this on other Alpine based containers if I face similar issues.
+          - name: ndots
+            value: "1"
+      containers:
+        - name: bazarr
+          image: ghcr.io/home-operations/bazarr:1.5.3 # renovate: docker=ghcr.io/home-operations/bazarr
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          ports:
+            - name: http
+              containerPort: 6767
+          envFrom:
+            - configMapRef:
+                name: common-env
+                optional: true
+          volumeMounts:
+            - name: bazarr-config
+              mountPath: /config
+            - name: tmp
+              mountPath: /tmp
+            - name: data
+              mountPath: /app/data
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 1000m
+              memory: 256Mi
+      volumes:
+        - name: bazarr-config
+          persistentVolumeClaim:
+            claimName: bazarr-config
+        - name: tmp
+          emptyDir: {}
+        - name: data
+          nfs:
+            server: 192.168.65.250
+            path: /volume1/media

--- a/k8s/apps/media/arr/bazarr/http-route.yaml
+++ b/k8s/apps/media/arr/bazarr/http-route.yaml
@@ -1,0 +1,19 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: bazarr
+  namespace: arr
+spec:
+  parentRefs:
+    - name: internal
+      namespace: gateway
+  hostnames:
+    - "bazarr.k8s.ghiot.be"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: bazarr
+          port: 80

--- a/k8s/apps/media/arr/bazarr/kustomization.yaml
+++ b/k8s/apps/media/arr/bazarr/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - pvc.yaml
+  - svc.yaml
+  - http-route.yaml
+  - deployment.yaml

--- a/k8s/apps/media/arr/bazarr/pvc.yaml
+++ b/k8s/apps/media/arr/bazarr/pvc.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: bazarr-config
+  namespace: arr
+spec:
+  storageClassName: proxmox-csi
+  volumeName: pv-bazarr
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 4G

--- a/k8s/apps/media/arr/bazarr/svc.yaml
+++ b/k8s/apps/media/arr/bazarr/svc.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: bazarr
+  namespace: arr
+spec:
+  type: ClusterIP
+  selector:
+    app: bazarr
+  ports:
+    - name: web
+      port: 80
+      targetPort: http

--- a/terraform/kubernetes/main.tf
+++ b/terraform/kubernetes/main.tf
@@ -175,5 +175,10 @@ module "volumes" {
       node = "hsp-proxmox0"
       size = "1G"
     }
+
+    pv-bazarr = {
+      node = "hsp-proxmox0"
+      size = "4G"
+    }
   }
 }


### PR DESCRIPTION
This pull request introduces a new deployment for the Bazarr media management application into the Kubernetes cluster. It adds all necessary Kubernetes manifests for deploying, exposing, and persisting data for Bazarr, as well as updates the Terraform configuration to provision the required persistent volume. Additionally, Bazarr is added to the project's custom dictionary for spell checking.

**Bazarr Kubernetes Deployment:**

* Added a new `Deployment` manifest for Bazarr, specifying container image, security context, resource requests/limits, volume mounts (including NFS and persistent storage), and node selection. (`k8s/apps/media/arr/bazarr/deployment.yaml`)
* Created a `Service` to expose Bazarr internally within the cluster on port 80. (`k8s/apps/media/arr/bazarr/svc.yaml`)
* Defined an `HTTPRoute` for Bazarr to route external traffic via the cluster's gateway, making it accessible at `bazarr.k8s.ghiot.be`. (`k8s/apps/media/arr/bazarr/http-route.yaml`)

**Persistent Storage:**

* Added a `PersistentVolumeClaim` manifest for Bazarr's configuration, using the `proxmox-csi` storage class and a dedicated volume. (`k8s/apps/media/arr/bazarr/pvc.yaml`)
* Updated the Terraform configuration to provision a 4GB persistent volume for Bazarr on the specified node. (`terraform/kubernetes/main.tf`)

**Configuration and Miscellaneous:**

* Created a `kustomization.yaml` to manage all Bazarr-related Kubernetes resources as a single unit. (`k8s/apps/media/arr/bazarr/kustomization.yaml`)
* Added "bazarr" to the project's custom spell-check dictionary. (`cspell-dict.txt`)