### PR TITLE
Add a FlareSolverr service

### DIFF
--- a/cspell-dict.txt
+++ b/cspell-dict.txt
@@ -66,6 +66,7 @@ esbuild
 eslint
 finalizer
 finops
+flaresolverr
 fmt
 FOWNER
 gatewayclass

--- a/k8s/apps/utils/flareSolverr/deployment.yaml
+++ b/k8s/apps/utils/flareSolverr/deployment.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: flaresolver
+  namespace: flaresolver
+  labels:
+    app: flaresolver
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: flaresolver
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: flaresolver
+    spec:
+      nodeSelector:
+        topology.kubernetes.io/zone: hsp-proxmox0
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: Always
+        seccompProfile:
+          type: RuntimeDefault
+      dnsConfig:
+        options:
+          # Lower ndots to avoid search-domain expansion issues (musl/glibc resolver short-circuit)
+          # and ensure external and cluster FQDNs resolve correctly.
+          # Use this on other Alpine based containers if I face similar issues.
+          - name: ndots
+            value: "1"
+      containers:
+        - name: flaresolver
+          image: ghcr.io/flaresolverr/flaresolverr:v3.4.4 # renovate: docker=ghcr.io/flaresolverr/flaresolverr
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            capabilities:
+              drop: ["ALL"]
+          ports:
+            - name: flaresolver
+              containerPort: 8191
+          env:
+            - name: LOG_LEVEL
+              value: "info"
+            - name: LOG_FILE
+              value: "/tmp/flaresolverr.log"
+            - name: TZ
+              value: "Europe/Brussels"
+
+          resources:
+            requests:
+              cpu: 100m
+              memory: 1.5Gi
+            limits:
+              cpu: 2000m
+              memory: 8Gi
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/k8s/apps/utils/flareSolverr/kustomization.yaml
+++ b/k8s/apps/utils/flareSolverr/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ns.yaml
+  - svc.yaml
+  - deployment.yaml

--- a/k8s/apps/utils/flareSolverr/ns.yaml
+++ b/k8s/apps/utils/flareSolverr/ns.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: flaresolver

--- a/k8s/apps/utils/flareSolverr/svc.yaml
+++ b/k8s/apps/utils/flareSolverr/svc.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: flaresolver
+  namespace: flaresolver
+spec:
+  type: ClusterIP
+  selector:
+    app: flaresolver
+  ports:
+    - name: web
+      port: 80
+      targetPort: flaresolver


### PR DESCRIPTION
This pull request introduces a new Kubernetes deployment for the `flaresolverr` utility. It adds all the necessary manifests to deploy, expose, and manage the `flaresolverr` service within its own namespace, and updates the spelling dictionary to include the new term. The most important changes are grouped below:

**Kubernetes Manifests for `flaresolverr`:**

* Added a new `Namespace` manifest (`ns.yaml`) to isolate the `flaresolverr` resources.
* Added a `Deployment` manifest (`deployment.yaml`) that defines how the `flaresolverr` container is run, including resource requests/limits, security context, node selection, and environment variables.
* Added a `Service` manifest (`svc.yaml`) to expose the `flaresolverr` deployment within the cluster via a `ClusterIP` service.
* Added a `Kustomization` file (`kustomization.yaml`) to manage and apply all the above manifests as a single unit.

**Other Updates:**

* Added `flaresolverr` to the spelling dictionary in `cspell-dict.txt` to prevent spellcheck errors on the new resource name.