### PR TITLE
Fix namespace typos in FlareSolverr service and update AppProject to …

### DIFF
--- a/k8s/apps/utils/flaresolverr/svc.yaml
+++ b/k8s/apps/utils/flaresolverr/svc.yaml
@@ -2,12 +2,12 @@ apiVersion: v1
 kind: Service
 metadata:
   name: flaresolverr
-  namespace: flaresolver
+  namespace: flaresolverr
 spec:
   type: ClusterIP
   selector:
-    app: flaresolver
+    app: flaresolverr
   ports:
     - name: web
       port: 80
-      targetPort: flaresolver
+      targetPort: flaresolverr

--- a/k8s/apps/utils/project.yaml
+++ b/k8s/apps/utils/project.yaml
@@ -11,6 +11,8 @@ spec:
       server: "*"
     - namespace: "torrent"
       server: "*"
+    - namespace: "flaresolverr"
+      server: "*"
   clusterResourceWhitelist:
     - group: "*"
       kind: "*"


### PR DESCRIPTION
This pull request updates the Kubernetes configuration for the `flaresolverr` utility to ensure consistent naming and proper namespace configuration. The main changes involve correcting the namespace and label references in the service definition and updating the project configuration to include the new namespace.

Kubernetes configuration updates:

* Updated the `k8s/apps/utils/flaresolverr/svc.yaml` file to use the correct `flaresolverr` namespace and label names throughout the service definition, ensuring consistency and preventing deployment issues.

Project configuration:

* Added the `flaresolverr` namespace to the list of allowed namespaces in `k8s/apps/utils/project.yaml`, enabling it to be managed correctly by the project.…include the correct namespace