### PR TITLE
fix(application-set): adjust syncOptions for network application set

### DIFF
--- a/k8s/infra/application-set.yaml
+++ b/k8s/infra/application-set.yaml
@@ -30,6 +30,3 @@ spec:
         automated:
           selfHeal: true
           prune: true
-        syncOptions:
-          - ApplyOutOfSyncOnly=true
-          - ServerSideApply=true

--- a/k8s/infra/network/application-set.yaml
+++ b/k8s/infra/network/application-set.yaml
@@ -30,3 +30,6 @@ spec:
         automated:
           selfHeal: true
           prune: true
+        syncOptions:
+          - ApplyOutOfSyncOnly=true
+          - ServerSideApply=true


### PR DESCRIPTION
Fix an issue where Cilium cannot apply the dashboard annotation.

```text
one or more objects failed to apply, reason: ConfigMap "cilium-dashboard" is invalid: metadata.annotations: Too long: may not be more than 262144 bytes (retried 5 times).
```

This pull request updates the synchronization options for ArgoCD ApplicationSets in the Kubernetes infrastructure configuration. Specifically, it moves the `syncOptions` settings from the `application-set.yaml` in the `infra` directory to the `network/application-set.yaml`, ensuring that only the network application set uses these advanced sync behaviors.

Configuration changes:

* Removed the `syncOptions` settings (`ApplyOutOfSyncOnly=true` and `ServerSideApply=true`) from `k8s/infra/application-set.yaml` to revert to default sync behavior for the general infra ApplicationSet.
* Added the same `syncOptions` to `k8s/infra/network/application-set.yaml`, enabling these options specifically for the network ApplicationSet.