### PR TITLE
fix(monitoring): increase Prometheus storage from 10G to 50G

### DIFF
--- a/k8s/infra/monitoring/prometheus-stack/values.yaml
+++ b/k8s/infra/monitoring/prometheus-stack/values.yaml
@@ -46,7 +46,7 @@ prometheus:
             - ReadWriteOnce
           resources:
             requests:
-              storage: 10G
+              storage: 50G
           selector:
             matchLabels:
               app: prometheus

--- a/terraform/kubernetes/main.tf
+++ b/terraform/kubernetes/main.tf
@@ -184,7 +184,7 @@ module "volumes" {
   volumes = {
     pv-prometheus = {
       node = "hsp-proxmox0"
-      size = "10G"
+      size = "50G"
     }
 
     pv-sonarr = {


### PR DESCRIPTION
Resolves Prometheus TSDB write failures caused by insufficient storage space. The 10G volume was completely full (100% utilization) after 22 days of operation, causing "no space left on device" errors and preventing new metric ingestion.

Changes:
- Increase Terraform volume size from 10G to 50G in main.tf
- Update Prometheus values.yaml to request 50G storage
- Provides room for ~6 months of metric retention vs previous 22 days

The immediate issue was resolved by cleaning old TSDB blocks and restarting Prometheus, but this permanent fix prevents future storage exhaustion.