### PR TITLE
chore(kustomize): remove unneeded comment

### DIFF
--- a/k8s/infra/controllers/cert-manager/kustomization.yaml
+++ b/k8s/infra/controllers/cert-manager/kustomization.yaml
@@ -10,7 +10,7 @@ resources:
 helmCharts:
   - name: cert-manager
     repo: https://charts.jetstack.io
-    version: v1.19.1 # renovate: github-releases=cert-manager/cert-manager
+    version: v1.19.1
     releaseName: cert-manager
     namespace: cert-manager
     valuesFile: values.yaml

--- a/k8s/infra/monitoring/grafana/kustomization.yaml
+++ b/k8s/infra/monitoring/grafana/kustomization.yaml
@@ -15,6 +15,6 @@ helmCharts:
     repo: oci://ghcr.io/grafana/helm-charts
     includeCRDs: true
     namespace: grafana
-    version: v5.20.0 # renovate: github-releases=grafana/grafana-operator
+    version: v5.20.0
     releaseName: grafana-operator
     valuesFile: ./values.yaml

--- a/k8s/infra/network/cilium/kustomization.yaml
+++ b/k8s/infra/network/cilium/kustomization.yaml
@@ -10,7 +10,7 @@ resources:
 helmCharts:
   - name: cilium
     repo: https://helm.cilium.io
-    version: 1.18.4 # renovate: github-releases=cilium/cilium
+    version: 1.18.4
     releaseName: "cilium"
     includeCRDs: true
     namespace: kube-system


### PR DESCRIPTION
This PR removes an unneeded comment from several `kustomization.yaml` files. Renovate can handle updating Kustomize dependencies, so the regex/workaround that previously existed is no longer required.

Files changed:
- `k8s/infra/controllers/cert-manager/kustomization.yaml`
- `k8s/infra/monitoring/grafana/kustomization.yaml`
- `k8s/infra/network/cilium/kustomization.yaml`

No functional changes to manifests — only cleanup to simplify future Renovate updates.