### PR TITLE
chore(dns): add plex.direct to private domains in unbound configuration

### DIFF
--- a/k8s/infra/network/dns/unbound/config/unbound.conf
+++ b/k8s/infra/network/dns/unbound/config/unbound.conf
@@ -167,6 +167,7 @@ server:
     private-domain: "ad.ghiot.be"
     private-domain: "k8s.ghiot.be"
     private-domain: "minecraft.ghiot.be"
+    private-domain: "plex.direct"
 
     local-zone: "k8s.ghiot.be" transparent
     local-zone: "ad.ghiot.be" transparent


### PR DESCRIPTION
This pull request makes a minor configuration update to the DNS server. The change adds the `plex.direct` domain to the list of private domains in the `unbound.conf` file.

The `plex.direct` domain resolves to private IPs.