### PR TITLE
fix: update destination namespace from pocket-id to auth in project.yaml

### DIFF
--- a/k8s/infra/auth/project.yaml
+++ b/k8s/infra/auth/project.yaml
@@ -10,7 +10,7 @@ spec:
   destinations:
     - namespace: "argocd"
       server: "*"
-    - namespace: "pocket-id"
+    - namespace: "auth"
       server: "*"
   clusterResourceWhitelist:
     - group: "*"


### PR DESCRIPTION
This pull request makes a small update to the Kubernetes project configuration, changing the namespace for one of the deployment destinations from `pocket-id` to `auth`.