### PR TITLE
feat: add OpenTelemetry metrics configuration to Pocket ID

### DIFF
--- a/k8s/infra/auth/pocket-id/kustomization.yaml
+++ b/k8s/infra/auth/pocket-id/kustomization.yaml
@@ -10,7 +10,10 @@ configMapGenerator:
       - DB_PROVIDER="postgres"
       - ENCRYPTION_KEY_FILE="/app/secrets/encryption_key.txt"
       - MAXMIND_LICENSE_KEY_FILE="/app/secrets/maxmind_api_key.txt"
-      - OTEL_METRICS_EXPORTER=prometheus
+      - METRICS_ENABLED="true"
+      - OTEL_METRICS_EXPORTER="prometheus"
+      - OTEL_EXPORTER_PROMETHEUS_HOST="0.0.0.0"
+      - OTEL_EXPORTER_PROMETHEUS_PORT="9464"
       - PGID="12501"
       - PUID="12501"
 


### PR DESCRIPTION
This pull request updates the Kubernetes configuration for the Pocket ID authentication service to improve observability and metrics support. The main changes focus on enabling metrics and configuring the OpenTelemetry Prometheus exporter.

**Metrics and observability enhancements:**

* Added `METRICS_ENABLED="true"` to explicitly enable metrics collection for the service.
* Updated `OTEL_METRICS_EXPORTER` to use a quoted value and added configuration for the Prometheus exporter host (`OTEL_EXPORTER_PROMETHEUS_HOST="0.0.0.0"`) and port (`OTEL_EXPORTER_PROMETHEUS_PORT="9464"`), allowing Prometheus to scrape metrics from the service.