### PR TITLE
fix: remove namespace declaration from kustomization.yaml

### DIFF
--- a/k8s/apps/finance/kustomization.yaml
+++ b/k8s/apps/finance/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: argocd
 
 commonLabels:
   be.ghiot: app-management


### PR DESCRIPTION
The problem was that the namespace: argocd line in the kustomization was applying the argocd namespace to ALL resources, including the namespace definition. Now each resource will use the namespace specified in its own metadata, which is correct:

The AppProject and ApplicationSet are already defined with namespace: argocd in their metadata
The namespace definition (ns.yaml) doesn't need a parent namespace
After you commit and push this change, ArgoCD should sync and the SharedResourceWarning will disappear.