### PR TITLE
fix: update push trigger to ignore main branch in pre-commit workflow

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -4,7 +4,8 @@ on:
   pull_request:
     branches: [main]
   push:
-    branches: [main]
+    branches-ignore: [main]
+  workflow_dispatch: # Manual trigger from GitHub UI
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
This pull request updates the workflow trigger configuration in `.github/workflows/pre-commit.yml`. The change ensures that the pre-commit workflow is not automatically triggered on pushes to the `main` branch, and adds support for manual workflow runs from the GitHub UI.

Workflow trigger improvements:

* Updated the `push` trigger to use `branches-ignore: [main]`, preventing the workflow from running on pushes to the `main` branch.
* Added `workflow_dispatch` to allow manual triggering of the workflow from the GitHub UI.