### PR TITLE
chore(deps): standardize Renovate datasource comments across various deployment files and update renovate.json configuration

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -10,25 +10,44 @@ ARG TZ=Europe/Brussels
 ENV TZ=$TZ
 
 # Tool versions - automatically updated by Renovate
-ARG ARGOCD_VERSION=v2.13.2      # renovate: datasource=github-releases depName=argoproj/argo-cd
-ARG EZA_VERSION=v0.20.14        # renovate: datasource=github-releases depName=eza-community/eza
-ARG HADOLINT_VERSION=v2.12.0    # renovate: datasource=github-releases depName=hadolint/hadolint
-ARG K9S_VERSION=v0.32.7         # renovate: datasource=github-releases depName=derailed/k9s
-ARG KUBECOLOR_VERSION=v0.4.0    # renovate: datasource=github-releases depName=kubecolor/kubecolor
-ARG KUBECONFORM_VERSION=v0.7.0  # renovate: datasource=github-releases depName=yannh/kubeconform
-ARG KUBECTX_VERSION=v0.9.5      # renovate: datasource=github-releases depName=ahmetb/kubectx
-ARG KUBESEAL_VERSION=v0.27.2    # renovate: datasource=github-releases depName=bitnami-labs/sealed-secrets
-ARG KUSTOMIZE_VERSION=v5.8.0    # renovate: datasource=github-releases depName=kubernetes-sigs/kustomize
-ARG LAZYGIT_VERSION=v0.44.1     # renovate: datasource=github-releases depName=jesseduffield/lazygit
-ARG GITLEAKS_VERSION=v8.30.0    # renovate: datasource=github-releases depName=gitleaks/gitleaks
-ARG STARSHIP_VERSION=v1.21.1    # renovate: datasource=github-releases depName=starship/starship
-ARG STERN_VERSION=v1.31.0       # renovate: datasource=github-releases depName=stern/stern
-ARG TALOS_VERSION=v1.9.2        # renovate: datasource=github-releases depName=siderolabs/talos
-ARG TASK_VERSION=v3.46.4        # renovate: datasource=github-releases depName=go-task/task
-ARG TFLINT_VERSION=v0.60.0      # renovate: datasource=github-releases depName=terraform-linters/tflint
-ARG TRIVY_VERSION=v0.58.1       # renovate: datasource=github-releases depName=aquasecurity/trivy
-ARG YQ_VERSION=v4.44.6          # renovate: datasource=github-releases depName=mikefarah/yq
-ARG CSPELL_VERSION=8.16.1       # renovate: datasource=npm depName=cspell
+# renovate: datasource=github-releases depName=argoproj/argo-cd
+ARG ARGOCD_VERSION=v2.13.2
+# renovate: datasource=github-releases depName=eza-community/eza
+ARG EZA_VERSION=v0.20.14
+# renovate: datasource=github-releases depName=hadolint/hadolint
+ARG HADOLINT_VERSION=v2.12.0
+# renovate: datasource=github-releases depName=derailed/k9s
+ARG K9S_VERSION=v0.32.7
+# renovate: datasource=github-releases depName=kubecolor/kubecolor
+ARG KUBECOLOR_VERSION=v0.4.0
+# renovate: datasource=github-releases depName=yannh/kubeconform
+ARG KUBECONFORM_VERSION=v0.7.0
+# renovate: datasource=github-releases depName=ahmetb/kubectx
+ARG KUBECTX_VERSION=v0.9.5
+# renovate: datasource=github-releases depName=bitnami-labs/sealed-secrets
+ARG KUBESEAL_VERSION=v0.27.2
+# renovate: datasource=github-releases depName=kubernetes-sigs/kustomize
+ARG KUSTOMIZE_VERSION=v5.8.0
+# renovate: datasource=github-releases depName=jesseduffield/lazygit
+ARG LAZYGIT_VERSION=v0.44.1
+# renovate: datasource=github-releases depName=gitleaks/gitleaks
+ARG GITLEAKS_VERSION=v8.30.0
+# renovate: datasource=github-releases depName=starship/starship
+ARG STARSHIP_VERSION=v1.21.1
+# renovate: datasource=github-releases depName=stern/stern
+ARG STERN_VERSION=v1.31.0
+# renovate: datasource=github-releases depName=siderolabs/talos
+ARG TALOS_VERSION=v1.9.2
+# renovate: datasource=github-releases depName=go-task/task
+ARG TASK_VERSION=v3.46.4
+# renovate: datasource=github-releases depName=terraform-linters/tflint
+ARG TFLINT_VERSION=v0.60.0
+# renovate: datasource=github-releases depName=aquasecurity/trivy
+ARG TRIVY_VERSION=v0.58.1
+# renovate: datasource=github-releases depName=mikefarah/yq
+ARG YQ_VERSION=v4.44.6
+# renovate: datasource=npm depName=cspell
+ARG CSPELL_VERSION=8.16.1
 
 # Install system dependencies grouped by purpose
 RUN <<EOF

--- a/k8s/apps/finance/wallos/deployment.yaml
+++ b/k8s/apps/finance/wallos/deployment.yaml
@@ -17,7 +17,7 @@ spec:
       labels:
         app: wallos
         app.kubernetes.io/name: wallos
-        app.kubernetes.io/version: 4.6.0 # renovate: docker=docker.io/bellamy/wallos
+        app.kubernetes.io/version: 4.6.0 # renovate: datasource=docker depName=docker.io/bellamy/wallos
     spec:
       nodeSelector:
         topology.kubernetes.io/zone: hsp-proxmox0
@@ -37,7 +37,7 @@ spec:
       containers:
         - name: wallos
           # TODO: switch to distroless (ghcr.io/wallos/wallos:v1.16-distroless) image when the deployment is stable.
-          image: docker.io/bellamy/wallos:4.6.0 # renovate: docker=docker.io/bellamy/wallos
+          image: docker.io/bellamy/wallos:4.6.0 # renovate: datasource=docker depName=docker.io/bellamy/wallos
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: false # wallos needs to write to some folders in the container itself for permissions updates

--- a/k8s/apps/media/arr/bazarr/deployment.yaml
+++ b/k8s/apps/media/arr/bazarr/deployment.yaml
@@ -37,7 +37,7 @@ spec:
             value: "1"
       containers:
         - name: bazarr
-          image: ghcr.io/home-operations/bazarr:1.5.4 # renovate: docker=ghcr.io/home-operations/bazarr
+          image: ghcr.io/home-operations/bazarr:1.5.4 # renovate: datasource=docker depName=ghcr.io/home-operations/bazarr
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/k8s/apps/media/arr/lidarr/deployment.yaml
+++ b/k8s/apps/media/arr/lidarr/deployment.yaml
@@ -37,7 +37,7 @@ spec:
             value: "1"
       containers:
         - name: lidarr
-          image: ghcr.io/home-operations/lidarr:3.1.2 # renovate: docker=ghcr.io/home-operations/lidarr
+          image: ghcr.io/home-operations/lidarr:3.1.2 # renovate: datasource=docker depName=ghcr.io/home-operations/lidarr
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/k8s/apps/media/arr/prowlarr/deployment.yaml
+++ b/k8s/apps/media/arr/prowlarr/deployment.yaml
@@ -37,7 +37,7 @@ spec:
             value: "1"
       containers:
         - name: prowlarr
-          image: ghcr.io/home-operations/prowlarr:2.3.2 # renovate: docker=ghcr.io/home-operations/prowlarr
+          image: ghcr.io/home-operations/prowlarr:2.3.2 # renovate: datasource=docker depName=ghcr.io/home-operations/prowlarr
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/k8s/apps/media/arr/radarr/deployment.yaml
+++ b/k8s/apps/media/arr/radarr/deployment.yaml
@@ -37,7 +37,7 @@ spec:
             value: "1"
       containers:
         - name: radarr
-          image: ghcr.io/home-operations/radarr:6.1.1 # renovate: docker=ghcr.io/home-operations/radarr
+          image: ghcr.io/home-operations/radarr:6.1.1 # renovate: datasource=docker depName=ghcr.io/home-operations/radarr
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/k8s/apps/media/arr/sonarr/deployment.yaml
+++ b/k8s/apps/media/arr/sonarr/deployment.yaml
@@ -37,7 +37,7 @@ spec:
             value: "1"
       containers:
         - name: sonarr
-          image: ghcr.io/home-operations/sonarr:4.0.16 # renovate: docker=ghcr.io/home-operations/sonarr
+          image: ghcr.io/home-operations/sonarr:4.0.16 # renovate: datasource=docker depName=ghcr.io/home-operations/sonarr
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/k8s/apps/utils/flaresolverr/deployment.yaml
+++ b/k8s/apps/utils/flaresolverr/deployment.yaml
@@ -36,7 +36,7 @@ spec:
             value: "1"
       containers:
         - name: flaresolverr
-          image: ghcr.io/flaresolverr/flaresolverr:v3.4.6 # renovate: docker=ghcr.io/flaresolverr/flaresolverr
+          image: ghcr.io/flaresolverr/flaresolverr:v3.4.6 # renovate: datasource=docker depName=ghcr.io/flaresolverr/flaresolverr
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: false

--- a/k8s/apps/utils/torrent/deployment.yaml
+++ b/k8s/apps/utils/torrent/deployment.yaml
@@ -36,7 +36,7 @@ spec:
             value: "1"
       containers:
         - name: git-sync-vuetorrent
-          image: registry.k8s.io/git-sync/git-sync:v4.5.1 # renovate: docker=registry.k8s.io/git-sync/git-sync
+          image: registry.k8s.io/git-sync/git-sync:v4.5.1 # renovate: datasource=docker depName=registry.k8s.io/git-sync/git-sync
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
@@ -64,7 +64,7 @@ spec:
               mountPath: /tmp
         - name: torrent
           # yamllint disable-line rule:line-length
-          image: ghcr.io/home-operations/qbittorrent@sha256:536b3e3fcfdc023f4ca49fc1ca4fb21cf48953c0ba1cd6cd368a398a984e2be8 # renovate: docker=ghcr.io/home-operations/qbittorrent
+          image: ghcr.io/home-operations/qbittorrent@sha256:536b3e3fcfdc023f4ca49fc1ca4fb21cf48953c0ba1cd6cd368a398a984e2be8 # renovate: datasource=docker depName=ghcr.io/home-operations/qbittorrent
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/k8s/infra/auth/pocket-id/pi-deployment.yaml
+++ b/k8s/infra/auth/pocket-id/pi-deployment.yaml
@@ -38,7 +38,7 @@ spec:
       containers:
         - name: pocket-id
           # TODO: switch to distroless (ghcr.io/pocket-id/pocket-id:v1.16-distroless) image when the deployment is stable.
-          image: ghcr.io/pocket-id/pocket-id:v2.2 # renovate: docker=ghcr.io/pocket-id/pocket-id
+          image: ghcr.io/pocket-id/pocket-id:v2.2 # renovate: datasource=docker depName=ghcr.io/pocket-id/pocket-id
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/k8s/infra/monitoring/grafana/grafana.yaml
+++ b/k8s/infra/monitoring/grafana/grafana.yaml
@@ -12,7 +12,7 @@ spec:
       mode: console
     server:
       root_url: https://grafana.k8s.ghiot.be
-  version: 12.3.1 # renovate: docker=docker.io/grafana/grafana
+  version: 12.3.1 # renovate: datasource=docker depName=docker.io/grafana/grafana
   deployment:
     spec:
       template:

--- a/k8s/infra/network/dns/adguard/deployment.yaml
+++ b/k8s/infra/network/dns/adguard/deployment.yaml
@@ -56,7 +56,7 @@ spec:
               mountPath: /opt/adguardhome/conf
       containers:
         - name: adguard
-          image: docker.io/adguard/adguardhome:v0.107.71 # renovate: docker=docker.io/adguard/adguardhome
+          image: docker.io/adguard/adguardhome:v0.107.71 # renovate: datasource=docker depName=docker.io/adguard/adguardhome
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/k8s/infra/network/dns/unbound/deployment.yaml
+++ b/k8s/infra/network/dns/unbound/deployment.yaml
@@ -17,7 +17,7 @@ spec:
       #    type: RuntimeDefault
       containers:
         - name: unbound
-          image: docker.io/mvance/unbound:1.22.0 # renovate: docker=docker.io/mvance/unbound
+          image: docker.io/mvance/unbound:1.22.0 # renovate: datasource=docker depName=docker.io/mvance/unbound
           # securityContext:
           #  allowPrivilegeEscalation: false
           #  readOnlyRootFilesystem: false

--- a/renovate.json
+++ b/renovate.json
@@ -4,20 +4,19 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
-        "/\\.tf$/",
-        "/\\.tftpl$/",
-        "/\\.yaml$/",
-        "/\\.sh$/",
-        "/Dockerfile/",
-        "/\\.tfvars$/"
+        "/\\.ya?ml$/",
+        "/\\.sh$/"
       ],
       "matchStrings": [
-        "(?<currentValue>[\\w+\\.\\-]*)['\",;]*\\s*#\\s?renovate: (?<datasource>\\S+)=(?<depName>\\S+)\\s?(registry=(?<registryUrl>\\S+))?\\s?(versioning=(?<versioning>\\S+))?\\s?(extractVersion=(?<extractVersion>\\S+))?"
+        "(?<currentValue>[\\w+\\.\\-]*)['\",;]*\\s*# renovate: datasource=(?<datasource>[a-zA-Z0-9-._]+) depName=(?<depName>\\S+)(?: (lookupName|packageName)=(?<packageName>\\S+))?(?: versioning=(?<versioning>\\S+))?(?: extractVersion=(?<extractVersion>\\S+))?(?: registryUrl=(?<registryUrl>\\S+))?"
       ]
     }
   ],
   "extends": [
-    "config:recommended",
+    "config:best-practices",
+    "customManagers:dockerfileVersions",
+    "customManagers:githubActionsVersions",
+    "customManagers:tfvarsVersions",
     ":enablePreCommit",
     ":rebaseStalePrs"
   ]

--- a/terraform/kubernetes/var_components_versions.auto.tfvars
+++ b/terraform/kubernetes/var_components_versions.auto.tfvars
@@ -1,5 +1,9 @@
-cilium_version       = "v1.18.5" # renovate: github-releases=cilium/cilium
-gateway_api_version  = "v1.3.0"  # renovate: github-releases=kubernetes-sigs/gateway-api
-kubernetes_version   = "v1.35.0" # renovate: github-releases=kubernetes/kubernetes
-talos_version        = "v1.12.0"
-talos_update_version = "v1.12.1" # renovate: github-releases=siderolabs/talos
+# renovate: datasource=github-releases depName=cilium/cilium
+cilium_version = "v1.18.5"
+# renovate: datasource=github-releases depName=kubernetes-sigs/gateway-api
+gateway_api_version = "v1.3.0"
+# renovate: datasource=github-releases depName=kubernetes/kubernetes
+kubernetes_version = "v1.35.0"
+talos_version      = "v1.12.0"
+# renovate: datasource=github-releases depName=siderolabs/talos
+talos_update_version = "v1.12.1"


### PR DESCRIPTION
This pull request standardizes and improves the way dependency update hints are provided for Renovate across multiple configuration and deployment files. The main change is switching from the older `# renovate: docker=...` and similar comments to the more explicit and structured `# renovate: datasource=... depName=...` format. This update ensures better compatibility and parsing by Renovate, and also updates the custom manager configuration to match the new conventions.

Key changes include:

**Standardization of Renovate Hints:**

* Updated all Docker image and version comments in Kubernetes deployment YAMLs and Terraform variable files to use the new `# renovate: datasource=... depName=...` format instead of the old `docker=` or similar hints. This affects images for applications like Wallos, Bazarr, Lidarr, Prowlarr, Radarr, Sonarr, FlareSolverr, Git Sync, Qbittorrent, Pocket ID, Grafana, AdGuard, and Unbound. [[1]](diffhunk://#diff-353b06ca29a318610ac29f7660dfa7965e66ff627562bb219333657904abe476L20-R20) [[2]](diffhunk://#diff-353b06ca29a318610ac29f7660dfa7965e66ff627562bb219333657904abe476L40-R40) [[3]](diffhunk://#diff-9205aac0ef8d68b68f1dd1431bab193a265a84e28abd50cd1e8faed5d7f45a2bL40-R40) [[4]](diffhunk://#diff-5f7d04346d109a410daa4046a9794bfdae1bbb6d3f039a2ecbaa7ca0366ed4d8L40-R40) [[5]](diffhunk://#diff-e9e35a37c3b59b38749dd1ebe4a2f1724932189df8d1c958422b6cc7b46d5331L40-R40) [[6]](diffhunk://#diff-e0b68ee593ff660bdf3287787039c0e38991c67c22f362810f4b71621bc38513L40-R40) [[7]](diffhunk://#diff-9416a650c516c2d998d6e75e207ef822df66e71b8495360d1e6a40bc0a0d8084L40-R40) [[8]](diffhunk://#diff-07017a0e04a18206f409fee2bfd03885075eed1e47558b49a065f39fe1551759L39-R39) [[9]](diffhunk://#diff-cfc180000ec435486117a9c31a3424fde686128ee9ff6d6b4ac68a86f1906549L39-R39) [[10]](diffhunk://#diff-cfc180000ec435486117a9c31a3424fde686128ee9ff6d6b4ac68a86f1906549L67-R67) [[11]](diffhunk://#diff-17e2ae91651c9c1d2c66c47d11409838ad8091f3c130070dcaaade3c0debbf95L41-R41) [[12]](diffhunk://#diff-30813b2a227d57da1e5d117d4f732bb5e0c6e3489465d845f3f8feaa7166f606L15-R15) [[13]](diffhunk://#diff-2622babd90a0b3f1b4696ab1fdba52a316da8d1a03855b8608b25faa8533caf4L59-R59) [[14]](diffhunk://#diff-0088e3d11ed8c47d69f8729941dfcb4dfe365a8f3858d8e49665035204c987daL20-R20) [[15]](diffhunk://#diff-d983ded18ffbbec4cb7fafd54971f37600716a8b63d5b618d50294a5bd5290b8L1-R9)

* In `.devcontainer/Dockerfile`, moved Renovate comments for tool versions to be above each `ARG` and updated them to the new format for consistency and improved parsing.

**Renovate Configuration Updates:**

* Modified the `renovate.json` custom manager configuration to recognize the new comment format, updated regex patterns, and switched to the `config:best-practices` preset. Also added custom managers for Dockerfile, GitHub Actions, and tfvars version tracking.

**Terraform Variable File Improvements:**

* Updated `terraform/kubernetes/var_components_versions.auto.tfvars` to use the new Renovate hint format for all tracked component versions.

These changes make Renovate automation more robust and future-proof by ensuring all dependency hints follow the recommended and supported format.