### PR TITLE
Update HashiCorp releases to use GitHub releases datasource

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -53,8 +53,8 @@ jobs:
           kubeconform: v0.7.0 # renovate: datasource=github-releases depName=yannh/kubeconform
           task: v3.46.4 # renovate: datasource=github-releases depName=go-task/task
           tflint: v0.60.0 # renovate: datasource=github-releases depName=terraform-linters/tflint
-          terraform: v1.14.3 # renovate: datasource=hashicorp-releases depName=terraform
-          packer: v1.14.3 # renovate: datasource=hashicorp-releases depName=packer
+          terraform: v1.14.3 # renovate: datasource=github-releases depName=hashicorp/packer
+          packer: v1.14.3 # renovate: datasource=github-releases depName=hashicorp/terraform
 
       - name: Install Node.js
         uses: actions/setup-node@v6


### PR DESCRIPTION
Switch the datasource for HashiCorp releases in the workflow configuration to use GitHub releases instead of the previous method.