### PR TITLE
Update qbittorrent image to 5.1.4 and enhance regex in renovate config

### DIFF
--- a/k8s/apps/utils/torrent/deployment.yaml
+++ b/k8s/apps/utils/torrent/deployment.yaml
@@ -64,7 +64,7 @@ spec:
               mountPath: /tmp
         - name: torrent
           # yamllint disable-line rule:line-length
-          image: ghcr.io/home-operations/qbittorrent@sha256:536b3e3fcfdc023f4ca49fc1ca4fb21cf48953c0ba1cd6cd368a398a984e2be8 # renovate: datasource=docker depName=ghcr.io/home-operations/qbittorrent
+          image: ghcr.io/home-operations/qbittorrent:5.1.4 # renovate: datasource=docker depName=ghcr.io/home-operations/qbittorrent
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/renovate.json
+++ b/renovate.json
@@ -2,13 +2,14 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "customManagers": [
     {
+      "autoReplaceStringTemplate": "{{{newValue}}}{{#if newDigest}}@{{{newDigest}}}{{/if}} # renovate: datasource={{{datasource}}} depName={{{depName}}}{{#if packageName}} packageName={{{packageName}}}{{/if}}{{#if versioning}} versioning={{{versioning}}}{{/if}}{{#if extractVersion}} extractVersion={{{extractVersion}}}{{/if}}{{#if registryUrl}} registryUrl={{{registryUrl}}}{{/if}}",
       "customType": "regex",
       "managerFilePatterns": [
         "/\\.ya?ml$/",
         "/\\.sh$/"
       ],
       "matchStrings": [
-        "(?<currentValue>[\\w+\\.\\-]*)['\",;]*\\s*# renovate: datasource=(?<datasource>[a-zA-Z0-9-._]+) depName=(?<depName>\\S+)(?: (lookupName|packageName)=(?<packageName>\\S+))?(?: versioning=(?<versioning>\\S+))?(?: extractVersion=(?<extractVersion>\\S+))?(?: registryUrl=(?<registryUrl>\\S+))?"
+        "(?<currentValue>[\\w.+-]+)(@(?<currentDigest>sha256:[a-fA-F0-9]{64}))?['\",;]*\\s+# renovate: datasource=(?<datasource>[a-zA-Z0-9._-]+) depName=(?<depName>\\S+)(?: (?:lookupName|packageName)=(?<packageName>\\S+))?(?: versioning=(?<versioning>\\S+))?(?: extractVersion=(?<extractVersion>\\S+))?(?: registryUrl=(?<registryUrl>\\S+))?"
       ]
     }
   ],


### PR DESCRIPTION
Update the qbittorrent image to version 5.1.4 and improve the regex for digest matching in the Renovate configuration to better handle versioning and digests.