### PR TITLE
Disable digest pinning for kustomize manager with docker datasource

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,5 +20,17 @@
     "customManagers:tfvarsVersions",
     ":enablePreCommit",
     ":rebaseStalePrs"
+  ],
+  "packageRules": [
+    {
+      "description": "Disable digest pinning for kustomize manager with docker datasource",
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchManagers": [
+        "kustomize"
+      ],
+      "pinDigests": false
+    }
   ]
 }


### PR DESCRIPTION
Disable digest pinning for the kustomize manager when using the docker datasource to allow for more flexibility in dependency management.