### PR TITLE
fix(ci): correct terraform and packer version renovate labels in pre-commit workflow

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -53,8 +53,8 @@ jobs:
           kubeconform: v0.7.0 # renovate: datasource=github-releases depName=yannh/kubeconform
           task: v3.48.0 # renovate: datasource=github-releases depName=go-task/task packageName=go-task/task versioning=semver-coerced registryUrl=https://github.com
           tflint: v0.60.0 # renovate: datasource=github-releases depName=terraform-linters/tflint
-          terraform: v1.14.3 # renovate: datasource=github-releases depName=hashicorp/packer
-          packer: v1.14.3 # renovate: datasource=github-releases depName=hashicorp/terraform
+          terraform: v1.14.4 # renovate: datasource=github-releases depName=hashicorp/terraform
+          packer: v1.14.3 # renovate: datasource=github-releases depName=hashicorp/packer
 
       - name: Install Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6


### PR DESCRIPTION
## Description
This PR fixes the renovate version labels for terraform and packer tools in the pre-commit workflow configuration.

## Changes
- Corrected the renovate datasource label for terraform (was pointing to hashicorp/packer)
- Corrected the renovate datasource label for packer (was pointing to hashicorp/terraform)
- Updated terraform version from v1.14.3 to v1.14.4

## Why
The renovate labels were swapped, causing incorrect version tracking and updates for these tools.

## Testing
- Pre-commit hooks pass locally
- CI pipeline will validate the changes