### PR TITLE
feat: migrate Kubernetes resources from deprecated to v1 API versions

### DIFF
--- a/terraform/kubernetes/modules/proxmox_csi_plugin/main.tf
+++ b/terraform/kubernetes/modules/proxmox_csi_plugin/main.tf
@@ -44,7 +44,7 @@ locals {
 }
 
 # Kubernetes namespace for Proxmox CSI plugin with privileged Pod Security Policy
-resource "kubernetes_namespace" "csi_proxmox" {
+resource "kubernetes_namespace_v1" "csi_proxmox" {
   metadata {
     name = "csi-proxmox"
     # Pod Security Policy labels allowing privileged containers required by CSI plugin
@@ -57,10 +57,10 @@ resource "kubernetes_namespace" "csi_proxmox" {
 }
 
 # Kubernetes secret containing Proxmox credentials for CSI plugin authentication
-resource "kubernetes_secret" "proxmox_csi_plugin" {
+resource "kubernetes_secret_v1" "proxmox_csi_plugin" {
   metadata {
     name      = "proxmox-csi-plugin"
-    namespace = kubernetes_namespace.csi_proxmox.id
+    namespace = kubernetes_namespace_v1.csi_proxmox.id
   }
 
   data = {

--- a/terraform/kubernetes/modules/proxmox_csi_plugin/outputs.tf
+++ b/terraform/kubernetes/modules/proxmox_csi_plugin/outputs.tf
@@ -1,16 +1,16 @@
 output "namespace" {
   description = "Kubernetes namespace where Proxmox CSI plugin is deployed"
-  value       = kubernetes_namespace.csi_proxmox.metadata[0].name
+  value       = kubernetes_namespace_v1.csi_proxmox.metadata[0].name
 }
 
 output "secret_name" {
   description = "Kubernetes secret name containing Proxmox credentials for CSI plugin"
-  value       = kubernetes_secret.proxmox_csi_plugin.metadata[0].name
+  value       = kubernetes_secret_v1.proxmox_csi_plugin.metadata[0].name
 }
 
 output "secret_namespace" {
   description = "Kubernetes namespace containing the CSI credentials secret"
-  value       = kubernetes_secret.proxmox_csi_plugin.metadata[0].namespace
+  value       = kubernetes_secret_v1.proxmox_csi_plugin.metadata[0].namespace
 }
 
 output "csi_user" {

--- a/terraform/kubernetes/modules/volumes/persistent_volume/config.tf
+++ b/terraform/kubernetes/modules/volumes/persistent_volume/config.tf
@@ -1,4 +1,4 @@
-resource "kubernetes_persistent_volume" "pv" {
+resource "kubernetes_persistent_volume_v1" "pv" {
 
   metadata {
     name = var.volume.name

--- a/terraform/kubernetes/modules/volumes/persistent_volume/outputs.tf
+++ b/terraform/kubernetes/modules/volumes/persistent_volume/outputs.tf
@@ -1,6 +1,6 @@
 output "pv_name" {
   description = "Name of the created Kubernetes PersistentVolume"
-  value       = kubernetes_persistent_volume.pv.metadata[0].name
+  value       = kubernetes_persistent_volume_v1.pv.metadata[0].name
 }
 
 output "storage_class" {


### PR DESCRIPTION
## Description
Migrates Kubernetes resources from deprecated API versions to their v1 counterparts to address provider deprecation warnings.

## Changes
- ✅ `kubernetes_secret` → `kubernetes_secret_v1` in proxmox_csi_plugin module
- ✅ `kubernetes_namespace` → `kubernetes_namespace_v1` in proxmox_csi_plugin module
- ✅ `kubernetes_persistent_volume` → `kubernetes_persistent_volume_v1` in volumes module (7 volumes: pv-bazarr, pv-lidarr, pv-prometheus, pv-prowlarr, pv-radarr, pv-sonarr, pv-torrent)

## Migration Process
- Removed deprecated resources from Terraform state
- Updated resource definitions to use v1 API versions
- Re-imported resources back to state under new resource types
- All outputs and references updated accordingly

## Testing
- ✅ All resources successfully imported into state
- ✅ Terraform plan shows no deprecation warnings for migrated resources
- ✅ No functional changes to resource configurations

## Files Modified
- `terraform/kubernetes/modules/proxmox_csi_plugin/main.tf`
- `terraform/kubernetes/modules/proxmox_csi_plugin/outputs.tf`
- `terraform/kubernetes/modules/volumes/persistent_volume/config.tf`
- `terraform/kubernetes/modules/volumes/persistent_volume/outputs.tf`