### PR TITLE
fix: update Grafana image version format in configuration

### DIFF
--- a/k8s/infra/monitoring/grafana/grafana.yaml
+++ b/k8s/infra/monitoring/grafana/grafana.yaml
@@ -12,7 +12,7 @@ spec:
       mode: console
     server:
       root_url: https://grafana.k8s.ghiot.be
-  version: 12.3.2@sha256:ba93c9d192e58b23e064c7f501d453426ccf4a85065bf25b705ab1e98602bfb1 # renovate: datasource=docker depName=docker.io/grafana/grafana packageName=docker.io/grafana/grafana versioning=docker registryUrl=https://index.docker.io
+  version: docker.io/grafana/grafana:12.3.2@sha256:ba93c9d192e58b23e064c7f501d453426ccf4a85065bf25b705ab1e98602bfb1 # renovate: datasource=docker depName=docker.io/grafana/grafana packageName=docker.io/grafana/grafana versioning=docker registryUrl=https://index.docker.io
   deployment:
     spec:
       template:


### PR DESCRIPTION
## Summary

Updates the Grafana image version format to include the full registry path.

## Changes

- Changed the version format from `12.3.2@sha256:...` to `docker.io/grafana/grafana:12.3.2@sha256:...`
- This ensures the full image reference is used, including the registry and repository path

## Files Changed

- `k8s/infra/monitoring/grafana/grafana.yaml`