### PR TITLE
feat(renovate): add approval requirement for Gateway API 1.4.x updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -31,6 +31,17 @@
         "kustomize"
       ],
       "pinDigests": false
+    },
+    {
+      "dependencyDashboardApproval": true,
+      "description": "Gateway API 1.4.x requires Cilium 1.20.0+ - require approval",
+      "matchNewVersion": ">=1.4.0",
+      "matchPackageNames": [
+        "kubernetes-sigs/gateway-api"
+      ],
+      "prBodyNotes": [
+        "\u26a0\ufe0f **Dependency Constraint**: Gateway API 1.4.x requires Cilium 1.20.0+. Ensure Cilium is updated first."
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds a Renovate package rule that requires manual approval from the Dependency Dashboard for Gateway API updates to version 1.4.0 or higher.

## Motivation

Gateway API 1.4.x requires Cilium 1.20.0+. Without this rule, Renovate could automatically create PRs to update Gateway API before Cilium is ready, which would break the cluster's networking.

## Changes

- Added `dependencyDashboardApproval: true` for Gateway API >= 1.4.0
- Included a warning note in PR body to remind about the Cilium dependency

## Testing

Once Cilium is upgraded to 1.20.0+, the Gateway API update can be approved from the Renovate Dependency Dashboard.