### PR TITLE
fix(k8s): correct controllerServiceAccount name in arc-runners values

### DIFF
--- a/k8s/infra/controllers/arc-runners/values-default.yaml
+++ b/k8s/infra/controllers/arc-runners/values-default.yaml
@@ -6,4 +6,4 @@ maxRunners: 5
 
 controllerServiceAccount:
   namespace: arc-systems
-  name: arc-systems-gha-runner-scale-set-controller
+  name: arc-systems-gha-rs-controller

--- a/k8s/infra/controllers/arc-runners/values-dind.yaml
+++ b/k8s/infra/controllers/arc-runners/values-dind.yaml
@@ -9,4 +9,4 @@ containerMode:
 
 controllerServiceAccount:
   namespace: arc-systems
-  name: arc-systems-gha-runner-scale-set-controller
+  name: arc-systems-gha-rs-controller


### PR DESCRIPTION
## What changed

- Fixed `controllerServiceAccount.name` in `values-default.yaml` and `values-dind.yaml` from `arc-systems-gha-runner-scale-set-controller` to `arc-systems-gha-rs-controller`

## Why

The ARC Helm chart generates the controller service account with an abbreviated name (`gha-rs-controller`, not `gha-runner-scale-set-controller`). The runner scale set chart uses `controllerServiceAccount.name` to create the RoleBinding that grants the controller read access to secrets in the runner namespace.

With the wrong name, the RoleBinding bound a non-existent service account, leaving the actual controller SA (`arc-systems-gha-rs-controller`) with no permission to read `arc-github-secret` in `arc-runners` — producing a persistent 403 that ARC's error handler swallowed as `failed to get kubernetes secret`.

Diagnosed by running a debug pod with the controller's service account and confirming a 403 from the API server, then comparing the pod's `.spec.serviceAccountName` against the RoleBinding subject.

## How to test

After ArgoCD syncs:
- `kubectl get rolebinding arc-runners-gha-rs-manager -n arc-runners -o jsonpath='{.subjects[0].name}'` → should now show `arc-systems-gha-rs-controller`
- `kubectl get autoscalingrunnersets -n arc-runners` → `STATE` column should move from `Pending` to `Running`
- `kubectl logs -n arc-systems -l app.kubernetes.io/instance=arc-systems --tail=20` → no more `failed to get kubernetes secret` errors

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)