### PR TITLE
fix: correct runner image name format in values-default.yaml

### DIFF
--- a/k8s/infra/controllers/arc-runners-home-infra/values-default.yaml
+++ b/k8s/infra/controllers/arc-runners-home-infra/values-default.yaml
@@ -12,4 +12,4 @@ template:
   spec:
     containers:
       - name: runner
-        image: "docker pull ghcr.io/cedsbe/actions-runner-cedsbe:latest"
+        image: "ghcr.io/cedsbe/actions-runner-cedsbe:latest"


### PR DESCRIPTION
This pull request makes a minor update to the `k8s/infra/controllers/arc-runners-home-infra/values-default.yaml` file, correcting the container image reference for the runner.

* Changed the `image` field for the `runner` container to use the correct image path (`ghcr.io/cedsbe/actions-runner-cedsbe:latest`), removing the unnecessary `docker pull` prefix.