### PR TITLE
Update sealed-secrets Helm chart repository URL

### DIFF
--- a/k8s/infra/controllers/sealed-secrets/kustomization.yaml
+++ b/k8s/infra/controllers/sealed-secrets/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 
 helmCharts:
   - name: sealed-secrets
-    repo: https://bitnami-labs.github.io/sealed-secrets
+    repo: https://bitnami.github.io/sealed-secrets
     version: 2.18.6
     releaseName: "sealed-secrets-controller"
     includeCRDs: true


### PR DESCRIPTION
This pull request updates the repository URL for the `sealed-secrets` Helm chart in the `k8s/infra/controllers/sealed-secrets/kustomization.yaml` file to point to the new upstream source.

Helm chart configuration:

* Updated the `repo` field for the `sealed-secrets` Helm chart from `https://bitnami-labs.github.io/sealed-secrets` to `https://bitnami.github.io/sealed-secrets` to ensure the chart is pulled from the correct repository.
* Bitnami migration. See https://github.com/bitnami/sealed-secrets/issues/1982