### PR TITLE
chore(k8s): pin arc runner image to specific SHA

### DIFF
--- a/k8s/infra/controllers/arc-runners-home-infra/values-default.yaml
+++ b/k8s/infra/controllers/arc-runners-home-infra/values-default.yaml
@@ -12,5 +12,5 @@ template:
   spec:
     containers:
       - name: runner
-        image: "ghcr.io/cedsbe/actions-runner-cedsbe:772c10293c9768ecb982cb2502ed8bba4e472d6a"
+        image: "ghcr.io/cedsbe/actions-runner-cedsbe@sha256:530306972196d1e4ff1c60f917dd08708face9606e74f6e42cca8868f4771261"
         command: ["/home/runner/run.sh"]

--- a/k8s/infra/controllers/arc-runners-home-infra/values-default.yaml
+++ b/k8s/infra/controllers/arc-runners-home-infra/values-default.yaml
@@ -12,5 +12,5 @@ template:
   spec:
     containers:
       - name: runner
-        image: "ghcr.io/cedsbe/actions-runner-cedsbe:latest"
+        image: "ghcr.io/cedsbe/actions-runner-cedsbe:772c10293c9768ecb982cb2502ed8bba4e472d6a"
         command: ["/home/runner/run.sh"]


### PR DESCRIPTION
## What changed

- Replaced `latest` tag with an immutable SHA digest for the `ghcr.io/cedsbe/actions-runner-cedsbe` image in the ARC runner Helm values

## Why

Using `latest` tags is disallowed by project convention and makes deployments non-deterministic. Pinning to a specific SHA ensures the runner image is immutable and reproducible across syncs.

## How to test

- `/k8s-status` — cluster state check
- Verify ArgoCD picks up the change and syncs the `arc-runners-home-infra` application without errors
