### PR TITLE
chore(renovate): group devcontainer non-major updates into a single PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -70,7 +70,7 @@
       ]
     },
     {
-      "description": "Group all non-major update in the .devcontainer directory into a single PR",
+      "description": "Group all non-major updates in the .devcontainer directory into a single PR",
       "groupName": "devcontainer non-major updates",
       "matchUpdateTypes": [
         "minor",

--- a/renovate.json
+++ b/renovate.json
@@ -68,6 +68,17 @@
       "prBodyNotes": [
         "\u26a0\ufe0f **Dependency Constraint**: Ensure the Gateway API version is supported by Cilium before merging. Check [Cilium Gateway API documentation](https://docs.cilium.io/en/stable/network/servicemesh/gateway-api/gateway-api/) for compatibility."
       ]
+    },
+    {
+      "description": "Group all non-major update in the .devcontainer directory into a single PR",
+      "groupName": "devcontainer non-major updates",
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "matchPaths": [
+        "devcontainer/**"
+      ]
     }
   ],
   "prBodyColumns": [

--- a/renovate.json
+++ b/renovate.json
@@ -76,8 +76,8 @@
         "minor",
         "patch"
       ],
-      "matchPaths": [
-        "devcontainer/**"
+      "matchFileNames": [
+        ".devcontainer/**"
       ]
     }
   ],


### PR DESCRIPTION
## What changed

- Add a Renovate packageRule that groups all non-major (minor/patch) updates under `devcontainer/**` into a single PR

## Why

Reduces PR noise from routine devcontainer dependency bumps by batching them into one grouped update instead of separate PRs per dependency.

## How to test

- `/validate-all` — general pre-commit check
- Review `renovate.json` for correct JSON schema and matchPaths glob
