### PR TITLE
chore(renovate): group non-major GitHub workflow updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -82,7 +82,7 @@
     },
     {
       "description": "Group all non-major updates in the .github/workflows directory into a single PR",
-      "groupName": "GitHub Workflows non-major updates",
+      "groupName": "github workflows non-major updates",
       "matchFileNames": [
         ".github/workflows/**"
       ],

--- a/renovate.json
+++ b/renovate.json
@@ -72,12 +72,23 @@
     {
       "description": "Group all non-major updates in the .devcontainer directory into a single PR",
       "groupName": "devcontainer non-major updates",
+      "matchFileNames": [
+        ".devcontainer/**"
+      ],
       "matchUpdateTypes": [
         "minor",
         "patch"
-      ],
+      ]
+    },
+    {
+      "description": "Group all non-major updates in the .github/workflows directory into a single PR",
+      "groupName": "GitHub Workflows non-major updates",
       "matchFileNames": [
-        ".devcontainer/**"
+        ".github/workflows/**"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
       ]
     }
   ],


### PR DESCRIPTION
## What changed

- Add a Renovate package rule grouping minor/patch updates under `.github/workflows/**` into a single PR

## Why

GitHub Actions workflow dependency bumps were arriving as separate PRs; grouping non-major updates reduces PR noise, consistent with the existing grouping rule for `.devcontainer/**`.

## How to test

- `/validate-all` — general pre-commit check
