### PR TITLE
feat(git-crypt): add unlock functionality for git-crypt in validation workflow

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -16,7 +16,8 @@
       "Bash(git rebase *)",
       "Bash(git stash *)",
       "Bash(git ls-remote *)",
-      "Bash(gh pr list *)"
+      "Bash(gh pr list *)",
+      "Bash(git add *)"
     ]
   }
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -17,7 +17,8 @@
       "Bash(git stash *)",
       "Bash(git ls-remote *)",
       "Bash(gh pr list *)",
-      "Bash(git add *)"
+      "Bash(git add *)",
+      "Bash(git commit -m ' *)"
     ]
   }
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,4 +1,9 @@
 {
+  "enableAllProjectMcpServers": true,
+  "enabledMcpjsonServers": [
+    "github",
+    "terraform"
+  ],
   "permissions": {
     "allow": [
       "WebSearch",
@@ -9,12 +14,9 @@
       "Bash(git remote *)",
       "Bash(git status *)",
       "Bash(git rebase *)",
-      "Bash(git stash *)"
+      "Bash(git stash *)",
+      "Bash(git ls-remote *)",
+      "Bash(gh pr list *)"
     ]
-  },
-  "enableAllProjectMcpServers": true,
-  "enabledMcpjsonServers": [
-    "github",
-    "terraform"
-  ]
+  }
 }

--- a/.github/workflows/validate-local-runners.yml
+++ b/.github/workflows/validate-local-runners.yml
@@ -56,6 +56,7 @@ jobs:
             git-crypt status
           else
             echo "❌ git-crypt is not installed"
+            exit 1
           fi
 
       - name: Unlock git-crypt
@@ -64,8 +65,11 @@ jobs:
         run: |
           echo "🔍 Unlocking git-crypt"
           echo "================================="
-          echo "$GIT_CRYPT_KEY_BASE64" | base64 --decode > git-crypt-key
-          if git-crypt unlock git-crypt-key; then
+          umask 077
+          KEY_FILE=$(mktemp)
+          trap 'rm -f "$KEY_FILE"' EXIT
+          echo "$GIT_CRYPT_KEY_BASE64" | base64 --decode > "$KEY_FILE"
+          if git-crypt unlock "$KEY_FILE"; then
             echo "✅ git-crypt unlocked successfully"
             echo "---------------------------------"
             echo "🔍 Display git-crypt canary file:"
@@ -73,8 +77,8 @@ jobs:
             echo "---------------------------------"
           else
             echo "❌ Failed to unlock git-crypt"
+            exit 1
           fi
-          rm -f git-crypt-key
 
       - name: Display Terraform version
         run: |
@@ -85,6 +89,7 @@ jobs:
             terraform version
           else
             echo "❌ Terraform is not installed"
+            exit 1
           fi
 
       - name: Folder structure

--- a/.github/workflows/validate-local-runners.yml
+++ b/.github/workflows/validate-local-runners.yml
@@ -58,6 +58,24 @@ jobs:
             echo "❌ git-crypt is not installed"
           fi
 
+      - name: Unlock git-crypt
+        env:
+          GIT_CRYPT_KEY_BASE64: ${{ secrets.GIT_CRYPT_KEY_BASE64 }}
+        run: |
+          echo "🔍 Unlocking git-crypt"
+          echo "================================="
+          echo "$GIT_CRYPT_KEY_BASE64" | base64 --decode > git-crypt-key
+          if git-crypt unlock git-crypt-key; then
+            echo "✅ git-crypt unlocked successfully"
+            echo "---------------------------------"
+            echo "🔍 Display git-crypt canary file:"
+            cat .git-crypt-canary
+            echo "---------------------------------"
+          else
+            echo "❌ Failed to unlock git-crypt"
+          fi
+          rm -f git-crypt-key
+
       - name: Display Terraform version
         run: |
           echo "🔍 Terraform Status"


### PR DESCRIPTION
## What changed

- Added an "Unlock git-crypt" step to `.github/workflows/validate-local-runners.yml`
- Decodes the `GIT_CRYPT_KEY_BASE64` secret to a temporary key file and runs `git-crypt unlock`
- Displays the `.git-crypt-canary` file to confirm the unlock succeeded, then removes the temporary key file

## Why

The validation workflow needs access to git-crypt encrypted files (e.g. `*.secrets.auto.tfvars`) during CI runs so downstream validation steps operate on decrypted content.

## How to test

- `/validate-all` — general pre-commit check
- Trigger the `validate-local-runners` workflow and confirm the "Unlock git-crypt" step succeeds and prints the canary file

