### PR TITLE
chore(k8s): pin arc-runner image tag alongside digest

### DIFF
--- a/k8s/infra/controllers/arc-runners-home-infra/values-default.yaml
+++ b/k8s/infra/controllers/arc-runners-home-infra/values-default.yaml
@@ -12,5 +12,5 @@ template:
   spec:
     containers:
       - name: runner
-        image: "ghcr.io/cedsbe/actions-runner-cedsbe@sha256:530306972196d1e4ff1c60f917dd08708face9606e74f6e42cca8868f4771261"
+        image: "ghcr.io/cedsbe/actions-runner-cedsbe:v1.0.0@sha256:2993eba02adcb90d368af949fbe423e3df86c898afaeffaa2488025947465e6c"
         command: ["/home/runner/run.sh"]


### PR DESCRIPTION
## What changed

- Added the `v1.0.0` tag to the `ghcr.io/cedsbe/actions-runner-cedsbe` runner image reference in `k8s/infra/controllers/arc-runners-home-infra/values-default.yaml`
- Note: the digest itself also changed (`sha256:530306...` → `sha256:2993eb...`) — this formalizes `v1.0.0` as a tagged build of the image, not just a cosmetic relabel of the same digest

## Why

Moving from an untagged digest-only reference to a tagged + digest-pinned reference (`v1.0.0@sha256:...`) improves readability while keeping the image immutable via digest pinning.

## How to test

- `kubectl get nodes -o wide` — verify cluster state
- `/validate-all` — general pre-commit check
- `/k8s-status` — cluster state check
