### PR TITLE
Add skeleton terraform workflow with OIDC

### DIFF
--- a/.github/workflows/terraform_azure_global.yml
+++ b/.github/workflows/terraform_azure_global.yml
@@ -12,6 +12,9 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    defaults:
+      run:
+        working-directory: terraform/azure/global
 
     steps:
       - name: Checkout code
@@ -20,6 +23,7 @@ jobs:
           fetch-depth: 0
 
       - name: Unlock git-crypt
+        id: unlock-git-crypt
         env:
           GIT_CRYPT_KEY_BASE64: ${{ secrets.GIT_CRYPT_KEY_BASE64 }}
         run: |
@@ -29,22 +33,30 @@ jobs:
           trap 'rm -f "$KEY_FILE"' EXIT
           echo "$GIT_CRYPT_KEY_BASE64" | base64 --decode > "$KEY_FILE"
           git-crypt unlock "$KEY_FILE"
+
       - name: Configure Terraform
+        id: terraform-setup
         uses: hashicorp/setup-terraform@v4
         with:
-          terraform_version: "1.15.8"
+          terraform_version: "1.15.8" # renovate: datasource=github-releases depName=hashicorp/terraform packageName=hashicorp/terraform versioning=semver-coerced  extractVersion=^v(?<version>.*)$ registryUrl=https://github.com
+
+      - name: Terraform fmt
+        id: fmt
+        run: terraform fmt -check
+        continue-on-error: true
 
       - name: Terraform Init
+        id: init
         run: terraform init -backend-config="backend.config"
-        working-directory: terraform/azure/global
         env:
           ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID_HOME_INFRA }}
           ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID_HOME_INFRA }}
           ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
           ARM_USE_OIDC: "true"
+
       - name: Terraform Validate
+        id: validate
         run: terraform validate
-        working-directory: terraform/azure/global
         env:
           ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID_HOME_INFRA }}
           ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID_HOME_INFRA }}
@@ -52,10 +64,70 @@ jobs:
           ARM_USE_OIDC: "true"
 
       - name: Terraform Plan
+        id: plan
         run: terraform plan -input=false
-        working-directory: terraform/azure/global
+        continue-on-error: true
         env:
           ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID_HOME_INFRA }}
           ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID_HOME_INFRA }}
           ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
           ARM_USE_OIDC: "true"
+
+      - uses: actions/github-script@v7
+        id: comment
+        if: github.event_name == 'pull_request'
+        env:
+          PLAN: "terraform\n${{ steps.plan.outputs.stdout }}"
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            // 1. Retrieve existing bot comments for the PR
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            })
+            const botComment = comments.find(comment => {
+              return comment.user.type === 'Bot' && comment.body.includes('Terraform Format and Style')
+            })
+
+            // 2. Prepare format of the comment
+            const output = `#### Terraform Format and Style 🖌\`${{ steps.fmt.outcome }}\`
+            #### Terraform Initialization ⚙️\`${{ steps.init.outcome }}\`
+            #### Terraform Validation 🤖\`${{ steps.validate.outcome }}\`
+            <details><summary>Validation Output</summary>
+
+            \`\`\`\n
+            ${{ steps.validate.outputs.stdout }}
+            \`\`\`
+
+            </details>
+
+            #### Terraform Plan 📖\`${{ steps.plan.outcome }}\`
+
+            <details><summary>Show Plan</summary>
+
+            \`\`\`\n
+            ${process.env.PLAN}
+            \`\`\`
+
+            </details>
+
+            *Pusher: @${{ github.actor }}, Action: \`${{ github.event_name }}\`, Workflow: \`${{ github.workflow }}\`*`;
+
+            // 3. If we have a comment, update it, otherwise create a new one
+            if (botComment) {
+              github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: output
+              })
+            } else {
+              github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: output
+              })
+            }

--- a/.github/workflows/terraform_azure_global.yml
+++ b/.github/workflows/terraform_azure_global.yml
@@ -5,10 +5,10 @@ on:
   pull_request:
 
 jobs:
-  terraform-validation:
+  terraform-validation-and-plan:
     runs-on: arc-runners-home-infra
     timeout-minutes: 15
-    name: "Terraform Validation"
+    name: "Terraform Validation and Plan"
     permissions:
       contents: read
       id-token: write
@@ -57,7 +57,7 @@ jobs:
 
       - name: Terraform Validate
         id: validate
-        run: terraform validate
+        run: terraform validate -no-color
         env:
           ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID_HOME_INFRA }}
           ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID_HOME_INFRA }}
@@ -66,7 +66,7 @@ jobs:
 
       - name: Terraform Plan
         id: plan
-        run: terraform plan -input=false
+        run: terraform plan -input=false -no-color
         continue-on-error: true
         env:
           ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID_HOME_INFRA }}
@@ -75,6 +75,7 @@ jobs:
           ARM_USE_OIDC: "true"
 
       - uses: actions/github-script@v9
+        name: "Comment on Pull Request"
         id: comment
         if: github.event_name == 'pull_request'
         env:
@@ -107,7 +108,7 @@ jobs:
 
             <details><summary>Show Plan</summary>
 
-            \`\`\`\n
+            \`\`\`terraform\n
             ${process.env.PLAN}
             \`\`\`
 

--- a/.github/workflows/terraform_azure_global.yml
+++ b/.github/workflows/terraform_azure_global.yml
@@ -1,4 +1,4 @@
-name: "Terraform Kubernetes Workflow"
+name: "Terraform Azure Global Workflow"
 
 on:
   - workflow_dispatch
@@ -14,12 +14,24 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v2.4.0
         with:
           fetch-depth: 0
 
+      - name: Unlock git-crypt
+        env:
+          GIT_CRYPT_KEY_BASE64: ${{ secrets.GIT_CRYPT_KEY_BASE64 }}
+        run: |
+          echo "🔍 Unlocking git-crypt"
+          umask 077
+          KEY_FILE=$(mktemp)
+          trap 'rm -f "$KEY_FILE"' EXIT
+          echo "$GIT_CRYPT_KEY_BASE64" | base64 --decode > "$KEY_FILE"
+          git-crypt unlock "$KEY_FILE"
       - name: Configure Terraform
         uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_version: "1.15.8"
 
       - name: Terraform Init
         run: terraform init -backend-config="backend.config"
@@ -28,7 +40,7 @@ jobs:
           ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID_HOME_INFRA }}
           ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID_HOME_INFRA }}
           ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
-
+          ARM_USE_OIDC: "true"
       - name: Terraform Validate
         run: terraform validate
         working-directory: terraform/azure/global
@@ -36,6 +48,7 @@ jobs:
           ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID_HOME_INFRA }}
           ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID_HOME_INFRA }}
           ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
+          ARM_USE_OIDC: "true"
 
       - name: Terraform Plan
         run: terraform plan -input=false
@@ -44,3 +57,4 @@ jobs:
           ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID_HOME_INFRA }}
           ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID_HOME_INFRA }}
           ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
+          ARM_USE_OIDC: "true"

--- a/.github/workflows/terraform_azure_global.yml
+++ b/.github/workflows/terraform_azure_global.yml
@@ -12,6 +12,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      pull-requests: write
     defaults:
       run:
         working-directory: terraform/azure/global
@@ -73,13 +74,12 @@ jobs:
           ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
           ARM_USE_OIDC: "true"
 
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@v9
         id: comment
         if: github.event_name == 'pull_request'
         env:
           PLAN: "terraform\n${{ steps.plan.outputs.stdout }}"
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             // 1. Retrieve existing bot comments for the PR
             const { data: comments } = await github.rest.issues.listComments({

--- a/.github/workflows/terraform_azure_global.yml
+++ b/.github/workflows/terraform_azure_global.yml
@@ -1,0 +1,46 @@
+name: "Terraform Kubernetes Workflow"
+
+on:
+  - workflow_dispatch
+
+jobs:
+  terraform-validation:
+    runs-on: arc-runners-home-infra
+    timeout-minutes: 15
+    name: "Terraform Validation"
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+
+      - name: Configure Terraform
+        uses: hashicorp/setup-terraform@v4
+
+      - name: Terraform Init
+        run: terraform init -backend-config="backend.config"
+        working-directory: terraform/azure/global
+        env:
+          ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID_HOME_INFRA }}
+          ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID_HOME_INFRA }}
+          ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
+
+      - name: Terraform Validate
+        run: terraform validate
+        working-directory: terraform/azure/global
+        env:
+          ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID_HOME_INFRA }}
+          ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID_HOME_INFRA }}
+          ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
+
+      - name: Terraform Plan
+        run: terraform plan -input=false
+        working-directory: terraform/azure/global
+        env:
+          ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID_HOME_INFRA }}
+          ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID_HOME_INFRA }}
+          ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}

--- a/.github/workflows/terraform_azure_global.yml
+++ b/.github/workflows/terraform_azure_global.yml
@@ -97,21 +97,17 @@ jobs:
             #### Terraform Initialization ⚙️\`${{ steps.init.outcome }}\`
             #### Terraform Validation 🤖\`${{ steps.validate.outcome }}\`
             <details><summary>Validation Output</summary>
-
-            \`\`\`\n
+            \`\`\`
             ${{ steps.validate.outputs.stdout }}
             \`\`\`
-
             </details>
 
             #### Terraform Plan 📖\`${{ steps.plan.outcome }}\`
 
             <details><summary>Show Plan</summary>
-
-            \`\`\`terraform\n
+            \`\`\`terraform
             ${process.env.PLAN}
             \`\`\`
-
             </details>
 
             *Pusher: @${{ github.actor }}, Action: \`${{ github.event_name }}\`, Workflow: \`${{ github.workflow }}\`*`;
@@ -132,3 +128,8 @@ jobs:
                 body: output
               })
             }
+
+      - name: Terraform Apply
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        run: terraform apply -auto-approve
+        working-directory: terraform/azure/global

--- a/.github/workflows/terraform_azure_global.yml
+++ b/.github/workflows/terraform_azure_global.yml
@@ -1,7 +1,8 @@
 name: "Terraform Azure Global Workflow"
 
 on:
-  - workflow_dispatch
+  workflow_dispatch:
+  pull_request:
 
 jobs:
   terraform-validation:

--- a/.github/workflows/terraform_azure_global.yml
+++ b/.github/workflows/terraform_azure_global.yml
@@ -97,7 +97,8 @@ jobs:
             #### Terraform Initialization ⚙️\`${{ steps.init.outcome }}\`
             #### Terraform Validation 🤖\`${{ steps.validate.outcome }}\`
             <details><summary>Validation Output</summary>
-            \`\`\`
+
+            \`\`\`\n
             ${{ steps.validate.outputs.stdout }}
             \`\`\`
             </details>
@@ -105,9 +106,11 @@ jobs:
             #### Terraform Plan 📖\`${{ steps.plan.outcome }}\`
 
             <details><summary>Show Plan</summary>
-            \`\`\`terraform
+
+            \`\`\`terraform\n
             ${process.env.PLAN}
             \`\`\`
+
             </details>
 
             *Pusher: @${{ github.actor }}, Action: \`${{ github.event_name }}\`, Workflow: \`${{ github.workflow }}\`*`;

--- a/terraform/azure/global/azuread_github_oidc.tf
+++ b/terraform/azure/global/azuread_github_oidc.tf
@@ -1,0 +1,92 @@
+# Azure AD App Registration for GitHub OIDC Integration
+# This app registration enables GitHub Actions to authenticate with Azure AD using OpenID Connect (OIDC)
+# Reference: https://docs.github.com/en/actions/how-tos/secure-your-work/security-harden-deployments/oidc-in-azure
+
+#region Azure AD Application
+resource "azuread_application" "github_oidc" {
+  display_name = "GitHub OIDC Integration"
+  description  = "OIDC application for GitHub Actions to authenticate with Azure AD"
+
+  tags = concat(
+    ["github_oidc"],
+    [for k, v in var.tags : "${k}:${v}"]
+  )
+}
+#endregion Azure AD Application
+
+#region Service Principal
+# Create service principal for the application
+resource "azuread_service_principal" "github_oidc" {
+  client_id = azuread_application.github_oidc.client_id
+
+  tags = concat(
+    ["github_oidc"],
+    [for k, v in var.tags : "${k}:${v}"]
+  )
+}
+#endregion Service Principal
+
+#region Federated Identity Credential
+# Create federated identity credential for GitHub OIDC
+resource "azuread_application_federated_identity_credential" "github_oidc_pr" {
+  application_id = azuread_application.github_oidc.id
+  display_name   = "github-oidc-home-infra-pr"
+  description    = "Federated identity credential for GitHub cedsbe/home-infra pull requests"
+  audiences      = ["api://AzureADTokenExchange"]
+  issuer         = "https://token.actions.githubusercontent.com"
+  subject        = "repo:cedsbe@8707686/home-infra@1032130197:pull_request"
+}
+
+resource "azuread_application_federated_identity_credential" "github_oidc_main" {
+  application_id = azuread_application.github_oidc.id
+  display_name   = "github-oidc-home-infra-main"
+  description    = "Federated identity credential for GitHub cedsbe/home-infra main branch"
+  audiences      = ["api://AzureADTokenExchange"]
+  issuer         = "https://token.actions.githubusercontent.com"
+  subject        = "repo:cedsbe@8707686/home-infra@1032130197:ref:refs/heads/main"
+}
+#endregion Federated Identity Credential
+
+#region Azure RBAC Role Assignments
+# Subscription-scope Contributor: manages resource groups, storage accounts, key
+# vault, and static web app resources across the azure-global and azure-landing
+# Terraform workspaces.
+resource "azurerm_role_assignment" "github_oidc_contributor" {
+  scope                = "/subscriptions/${data.azurerm_client_config.current.subscription_id}"
+  role_definition_name = "Contributor"
+  principal_id         = azuread_service_principal.github_oidc.object_id
+}
+
+# Storage Blob Data Contributor on the Terraform backend storage account: required
+# because backend.tf uses `use_azuread_auth = true`, so state access goes through
+# Azure AD RBAC on the blob data plane rather than the storage account access key.
+resource "azurerm_role_assignment" "github_oidc_storage_blob_data_contributor" {
+  scope                = azurerm_storage_account.backend.id
+  role_definition_name = "Storage Blob Data Contributor"
+  principal_id         = azuread_service_principal.github_oidc.object_id
+}
+
+# Key Vault Secrets Officer on the shared key vault: required because
+# rbac_authorization_enabled = true means Contributor (control plane) does not
+# grant secret read/write access; a data-plane role is needed separately.
+resource "azurerm_role_assignment" "github_oidc_key_vault_secrets_officer" {
+  scope                = azurerm_key_vault.main.id
+  role_definition_name = "Key Vault Secrets Officer"
+  principal_id         = azuread_service_principal.github_oidc.object_id
+}
+#endregion Azure RBAC Role Assignments
+
+#region Entra ID Directory Role Assignment
+# Application Administrator: required because this workspace manages
+# azuread_application / azuread_service_principal / federated identity credential /
+# application password resources, including this app's own federated credentials.
+# Azure RBAC role assignments above do not cover Microsoft Entra ID object management.
+resource "azuread_directory_role" "application_administrator" {
+  display_name = "Application Administrator"
+}
+
+resource "azuread_directory_role_assignment" "github_oidc_application_administrator" {
+  role_id             = azuread_directory_role.application_administrator.template_id
+  principal_object_id = azuread_service_principal.github_oidc.object_id
+}
+#endregion Entra ID Directory Role Assignment


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow and supporting Terraform configuration to enable secure authentication from GitHub Actions to Azure using OpenID Connect (OIDC). The main changes set up an Azure AD application for OIDC integration, configure federated identity credentials for both pull request and main branch workflows, and assign the necessary Azure RBAC and Entra ID roles for resource access and management.

**CI/CD Workflow Integration**
* Adds a new GitHub Actions workflow (`.github/workflows/terraform_azure_global.yml`) to automate Terraform validation and planning for the `terraform/azure/global` environment, using OIDC for authentication.

**Azure AD OIDC Integration**
* Creates a new Azure AD application, service principal, and federated identity credentials to allow GitHub Actions workflows to authenticate securely with Azure via OIDC.
* Configures federated identity credentials for both pull request and main branch workflows, ensuring least-privilege access for each workflow type.

**Access Control and Permissions**
* Assigns Contributor, Storage Blob Data Contributor, and Key Vault Secrets Officer roles to the service principal, providing the necessary permissions for Terraform operations across Azure resources, backend storage, and Key Vault.
* Assigns the Application Administrator directory role to the service principal, enabling management of Azure AD objects required by the Terraform workspace.